### PR TITLE
feat: support connection flags

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -31,6 +31,13 @@ Various options are accepted:
 
 - `options.fileMustExist`: if the database does not exist, an `Error` will be thrown instead of creating a new file. This option is ignored for in-memory, temporary, or readonly database connections (default: `false`).
 
+- `options.flags`: flags to use when opening the database connection (default: `0`). Supported flag constants are available as properties of the `Database.Constants` object with the `OPEN_` prefix.
+
+```js
+const Database = require('better-sqlite3');
+const db = new Database('file:foobar.db', { flags: Database.Constants.OPEN_URI });
+```
+
 - `options.timeout`: the number of milliseconds to wait when executing queries on a locked database, before throwing a `SQLITE_BUSY` error (default: `5000`).
 
 - `options.verbose`: provide a function that gets called with every SQL string executed by the database connection (default: `null`).

--- a/lib/database.js
+++ b/lib/database.js
@@ -4,9 +4,11 @@ const path = require('path');
 const util = require('./util');
 
 const {
+	Constants,
 	Database: CPPDatabase,
 	setErrorConstructor,
 } = require('bindings')('better_sqlite3.node');
+const { OPEN_URI } = Constants;
 
 function Database(filenameGiven, options) {
 	if (new.target == null) {
@@ -35,20 +37,22 @@ function Database(filenameGiven, options) {
 	const fileMustExist = util.getBooleanOption(options, 'fileMustExist');
 	const timeout = 'timeout' in options ? options.timeout : 5000;
 	const verbose = 'verbose' in options ? options.verbose : null;
+	const flags = 'flags' in options ? options.flags : 0;
 
 	// Validate interpreted options
 	if (readonly && anonymous && !buffer) throw new TypeError('In-memory/temporary databases cannot be readonly');
 	if (!Number.isInteger(timeout) || timeout < 0) throw new TypeError('Expected the "timeout" option to be a positive integer');
 	if (timeout > 0x7fffffff) throw new RangeError('Option "timeout" cannot be greater than 2147483647');
 	if (verbose != null && typeof verbose !== 'function') throw new TypeError('Expected the "verbose" option to be a function');
+	if (!Number.isInteger(flags)) throw new TypeError('Expected the "flags" option to be an integer');
 
 	// Make sure the specified directory exists
-	if (!anonymous && !fs.existsSync(path.dirname(filename))) {
+	if (!anonymous && (flags & OPEN_URI) !== OPEN_URI && !fs.existsSync(path.dirname(filename))) {
 		throw new TypeError('Cannot open database because the directory does not exist');
 	}
 
 	Object.defineProperties(this, {
-		[util.cppdb]: { value: new CPPDatabase(filename, filenameGiven, anonymous, readonly, fileMustExist, timeout, verbose || null, buffer || null) },
+		[util.cppdb]: { value: new CPPDatabase(filename, filenameGiven, anonymous, readonly, fileMustExist, timeout, verbose || null, buffer || null, flags) },
 		...wrappers.getters,
 	});
 }
@@ -68,6 +72,8 @@ Database.prototype.close = wrappers.close;
 Database.prototype.defaultSafeIntegers = wrappers.defaultSafeIntegers;
 Database.prototype.unsafeMode = wrappers.unsafeMode;
 Database.prototype[util.inspect] = require('./methods/inspect');
+
+Database.Constants = Constants;
 
 module.exports = Database;
 setErrorConstructor(require('./sqlite-error'));


### PR DESCRIPTION
Rough patch that adds a constructor option for passing flags to `sqlite3_open_v2`. This would enable several situations listed in #483, like using a URI, without needing a custom build.

```js
const Database = require('better-sqlite3');
const db = new Database('file:foobar.db', { flags: Database.Constants.OPEN_URI });
```

Relevant `SQLITE_OPEN_*` constants are exposed through `Database.Constants` (in case non-opening constants want to be exposed later).

API feels weird, would like some feedback on that.

EDIT: forgot `SQLITE_OMIT_SHARED_CACHE` removes shared cache support, removing that reference...