### PR TITLE
Update troubleshooting.md

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,11 +4,13 @@ If you have trouble installing `better-sqlite3`, follow this checklist:
 
 1. Make sure you're using nodejs v10.20.1 or later
 
-2. Make sure you have [`node-gyp`](https://github.com/nodejs/node-gyp#installation) globally installed, including all of [its dependencies](https://github.com/nodejs/node-gyp#on-unix). On Windows you may need to [configure some things manually](https://github.com/nodejs/node-gyp#on-windows). Use `npm ls node-gyp` to make sure none of your local packages installed an outdated version of `node-gyp` that is used over the global one.
+2. Make sure there are no spaces in the path of the directory you are installing in
 
-3. If you're using [Electron](https://github.com/electron/electron), try running [`electron-rebuild`](https://www.npmjs.com/package/electron-rebuild)
+3. Make sure you have [`node-gyp`](https://github.com/nodejs/node-gyp#installation) globally installed, including all of [its dependencies](https://github.com/nodejs/node-gyp#on-unix). On Windows you may need to [configure some things manually](https://github.com/nodejs/node-gyp#on-windows). Use `npm ls node-gyp` to make sure none of your local packages installed an outdated version of `node-gyp` that is used over the global one.
 
-4. If you're using Windows, follow these steps. Do them **in this order**, and **don't skip steps**.
+4. If you're using [Electron](https://github.com/electron/electron), try running [`electron-rebuild`](https://www.npmjs.com/package/electron-rebuild)
+
+5. If you're using Windows, follow these steps. Do them **in this order**, and **don't skip steps**.
 
     1. Install the **latest** of node 10, 12, or 14.
     2. Install **latest** Visual Studio Community and Desktop Development with C++ extension.


### PR DESCRIPTION
As I just learned, having spaces in the path of the directory which you are running `npm i better-sqlite3` can cause issues with installation, presumably because, according to the error message, it does not insert escapes for characters like spaces. I just wasted two days, and I don't want anyone else to do so.