### PR TITLE
Temporary fix for snyk alert in ansi-regex 

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,12 @@
     "bindings": "^1.5.0",
     "prebuild-install": "^7.1.0"
   },
+  "overrides": {
+    "ansi-regex": "5.0.1"
+  },
+  "resolutions": {
+    "ansi-regex": "5.0.1"
+  },
   "devDependencies": {
     "chai": "^4.3.6",
     "cli-color": "^2.0.2",


### PR DESCRIPTION
UGH.

[prebuild-install won't upgrade npmlog](https://github.com/prebuild/prebuild-install/pull/180), because [npmlog dropped node 14 support](https://github.com/prebuild/prebuild-install/issues/163). 

Duct tape and bailing wire to the rescue, I guess.