### PR TITLE
Update `prebuild` dependency to v11.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "fs-extra": "^10.1.0",
     "mocha": "^8.3.2",
     "nodemark": "^0.3.0",
-    "prebuild": "^11.0.3",
+    "prebuild": "^11.0.4",
     "sqlite": "^4.1.1",
     "sqlite3": "^5.0.8"
   },


### PR DESCRIPTION
This PR ensures _(even though all semver patches are already accepted for `prebuild`)_ that Electron headers are properly pulled in the build process for newer Electron versions, since https://github.com/prebuild/prebuild/pull/292 is now merged and included in v11.0.4.

This PR will also allow #834 to be merged. 

- [A successful test build for reference](https://github.com/m4heshd/better-sqlite3-multiple-ciphers/actions/runs/2678671957)