### PR TITLE
Remove `npm run` from `install` lifecycle script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "sqlite3": "^5.0.8"
   },
   "scripts": {
-    "install": "prebuild-install || npm run build-release",
+    "install": "prebuild-install || node-gyp rebuild --release",
     "build-release": "node-gyp rebuild --release",
     "build-debug": "node-gyp rebuild --debug",
     "rebuild-release": "npm run lzz && npm run build-release",


### PR DESCRIPTION
This ensures compatibility with all package manager installation choices.

Closes #893.