### PR TITLE
load default extensions from a file

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -63,6 +63,28 @@ function Database(filenameGiven, options) {
 		[util.cppdb]: { value: new addon.Database(filename, filenameGiven, anonymous, readonly, fileMustExist, timeout, verbose || null, buffer || null) },
 		...wrappers.getters,
 	});
+
+	// load default extensions
+	try {
+		const configFile = path.join(require.main.path, 'better-sqlite-extensions');
+		if (fs.existsSync(configFile)) {
+			const extensions = fs.readFileSync(configFile, {
+				encoding: "utf8"
+			}).split(/\r\n|\r|\n/).filter(value => value);
+
+			for (let extension of extensions) {
+				try {
+					this.loadExtension(extension);
+				}
+				catch (e) {
+					console.error(e);
+				}
+			}
+		}
+	}
+	catch (e) {
+		console.error(e);
+	}
 }
 
 const wrappers = require('./methods/wrappers');


### PR DESCRIPTION
I think this is a very useful feature.
When you are certain that the whole application needs access to a couple of extensions.

In stead of adding them manually after every connection you can just create a file in the root of your project and add a list of paths to extensions you want to make available for every connection.