### PR TITLE
Fix `pr_body` text of `update-sqlite` workflow

### DIFF
--- a/.github/workflows/update-sqlite.yml
+++ b/.github/workflows/update-sqlite.yml
@@ -45,4 +45,4 @@ jobs:
           github_token: ${{ secrets.PAT }}
           source_branch: sqlite-update-${{ env.ENV_VERSION }}
           pr_title: Update SQLite to version ${{ env.ENV_TRUE_VERSION }}
-          pr_body: This is an automated pull request, updating SQLite to version \`${{ env.ENV_TRUE_VERSION }}\`.
+          pr_body: This is an automated pull request, updating SQLite to version `${{ env.ENV_TRUE_VERSION }}`.


### PR DESCRIPTION
The latest version of the `repo-sync/pull-request` (v2) action parses template text differently.

Previously backticks had to be escaped, but not anymore. Backslashes are removed so the backticks won't be parsed as literals in the PR body, as seen in the following screenshot.

![image](https://user-images.githubusercontent.com/6711514/217234360-41c71689-c964-43fb-8257-2acd430389a7.png)
