### PR TITLE
Explicitly support node 19

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,6 @@ on:
   workflow_dispatch: {}
 
 jobs:
-
   test:
     strategy:
       matrix:
@@ -25,6 +24,7 @@ jobs:
           - 14
           - 16
           - 18
+          - 19
     name: Testing Node ${{ matrix.node }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -24,7 +24,7 @@ If you have trouble installing `better-sqlite3`, follow this checklist:
 
 If you still have issues on Windows and are on an older version of Node, try these steps:
 
-1. Install the **latest** of node 14, 16, or 18.
+1. Install the **latest** of node 14, 16, 18, or 19.
 1. Install **latest** Visual Studio Community and Desktop Development with C++ extension.
 1. Install **latest** Python.
 1. Run following commands:


### PR DESCRIPTION
The current version of better-sqlite3 seems to be compatible with the latest Node 19, which is great news! This PR adds it to the list of node versions tested in the build workflow, and in the list of recommended versions in the troubleshooting docs. This does add a job run to the `test` job. 

Small flag also that [Node 14 is going end of life next month](https://nodejs.org/en/blog/announcements/v19-release-announce/), so maybe we don't want to keep explicitly testing it after that?