### PR TITLE
Change Linux runner image to `ubuntu-20.04`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
   publish:
     if: ${{ github.event_name == 'release' }}
     name: Publishing to NPM
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: test
     steps:
       - uses: actions/checkout@v3
@@ -55,7 +55,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-18.04
+          - ubuntu-20.04
           - macos-latest
           - windows-2019
     name: Prebuild on ${{ matrix.os }}


### PR DESCRIPTION
This change is necessary since GitHub has dropped support for the `ubuntu-18.04` image. (https://github.com/actions/runner-images/issues/6002)

This will also mean that Linux distributions with only glibc version `2.29` and above will be supported by the prebuilt binaries.