### PR TITLE
Remove node.js v14 builds and tests (runtime EOL)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  NODE_BUILD_CMD: npx --no-install prebuild -r node -t 14.0.0 -t 16.0.0 -t 18.0.0 -t 20.0.0 --include-regex 'better_sqlite3.node$'
+  NODE_BUILD_CMD: npx --no-install prebuild -r node -t 16.0.0 -t 18.0.0 -t 20.0.0 --include-regex 'better_sqlite3.node$'
   ELECTRON_BUILD_CMD: npx --no-install prebuild -r electron -t 16.0.0 -t 17.0.0 -t 18.0.0 -t 19.0.0 -t 20.0.0 -t 21.0.0 -t 22.0.0 -t 23.0.0 -t 24.0.0 --include-regex 'better_sqlite3.node$'
 
 jobs:
@@ -25,10 +25,8 @@ jobs:
           - macos-latest
           - windows-2019
         node:
-          - 14
           - 16
           - 18
-          - 19
           - 20
     name: Testing Node ${{ matrix.node }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Node v14 just reached EOL. This would be a proactive measure to avoid getting bombarded with build errors in future builds. This would also make tests and builds finish quicker. Not vital to test against a runtime that isn't actively supported anymore.

I've also removed the quite unnecessary non-LTS tests for Node v19 _(which also will soon reach EOL)_.