### PR TITLE
Fix: Create target directory when copying  

### DIFF
--- a/deps/copy.js
+++ b/deps/copy.js
@@ -21,6 +21,13 @@ for (const { filename, optional } of files) {
 	if (optional && !fs.existsSync(path.join(source, filename))) {
 		continue;
 	}
+
 	fs.accessSync(path.join(source, filename));
+
+	// Ensure destination folder exists
+	const destFolder = path.dirname(path.join(dest, filename));
+	fs.mkdirSync(destFolder, { recursive: true });
+
+	// Copy file over
 	fs.copyFileSync(path.join(source, filename), path.join(dest, filename));
 }


### PR DESCRIPTION
For various complicated reasons, I have to build `better-sqlite3` with an empty `build/Release` folder. If that's the case, `copy.js` will fail to create directories before attempting to copy files, which will in turn fail.

This PR ensures that we create target directories before copying files.
