### PR TITLE
Fix binding of explicitly numbered parameters

### DIFF
--- a/src/better_sqlite3.cpp
+++ b/src/better_sqlite3.cpp
@@ -785,7 +785,7 @@ BindMap * Statement::GetBindMap (v8::Isolate * isolate)
                 int param_count = sqlite3_bind_parameter_count(handle);
                 for (int i = 1; i <= param_count; ++i) {
                         const char* name = sqlite3_bind_parameter_name(handle, i);
-                        if (name != NULL) bind_map->Add(isolate, name + 1, i);
+                        if (name != NULL && name[0] != '?') bind_map->Add(isolate, name + 1, i);
                 }
                 has_bind_map = true;
                 return bind_map;
@@ -1983,15 +1983,22 @@ void Binder::Fail (void (* Throw) (char const *), char const * message)
                 success = false;
 }
 #line 63 "./src/util/binder.lzz"
-int Binder::NextAnonIndex ()
+bool Binder::IsAnonIndex (int index)
 #line 63 "./src/util/binder.lzz"
+                                    {
+                const char* name = sqlite3_bind_parameter_name(handle, index);
+                return name == NULL || name[0] == '?';
+}
+#line 68 "./src/util/binder.lzz"
+int Binder::NextAnonIndex ()
+#line 68 "./src/util/binder.lzz"
                             {
-                while (sqlite3_bind_parameter_name(handle, ++anon_index) != NULL) {}
+                while (!IsAnonIndex(++anon_index)) {}
                 return anon_index;
 }
-#line 69 "./src/util/binder.lzz"
+#line 74 "./src/util/binder.lzz"
 void Binder::BindValue (v8::Isolate * isolate, v8::Local <v8::Value> value, int index)
-#line 69 "./src/util/binder.lzz"
+#line 74 "./src/util/binder.lzz"
                                                                                     {
                 int status = Data::BindValueFromJS(isolate, handle, index, value);
                 if (status != SQLITE_OK) {
@@ -2010,9 +2017,9 @@ void Binder::BindValue (v8::Isolate * isolate, v8::Local <v8::Value> value, int 
                         assert(false);
                 }
 }
-#line 90 "./src/util/binder.lzz"
+#line 95 "./src/util/binder.lzz"
 int Binder::BindArray (v8::Isolate * isolate, v8::Local <v8::Array> arr)
-#line 90 "./src/util/binder.lzz"
+#line 95 "./src/util/binder.lzz"
                                                                       {
                 v8 :: Local < v8 :: Context > ctx = isolate -> GetCurrentContext ( ) ;
                 uint32_t length = arr->Length();
@@ -2034,9 +2041,9 @@ int Binder::BindArray (v8::Isolate * isolate, v8::Local <v8::Array> arr)
                 }
                 return len;
 }
-#line 116 "./src/util/binder.lzz"
+#line 121 "./src/util/binder.lzz"
 int Binder::BindObject (v8::Isolate * isolate, v8::Local <v8::Object> obj, Statement * stmt)
-#line 116 "./src/util/binder.lzz"
+#line 121 "./src/util/binder.lzz"
                                                                                          {
                 v8 :: Local < v8 :: Context > ctx = isolate -> GetCurrentContext ( ) ;
                 BindMap* bind_map = stmt->GetBindMap(isolate);
@@ -2073,9 +2080,9 @@ int Binder::BindObject (v8::Isolate * isolate, v8::Local <v8::Object> obj, State
 
                 return len;
 }
-#line 160 "./src/util/binder.lzz"
+#line 165 "./src/util/binder.lzz"
 Binder::Result Binder::BindArgs (v8::FunctionCallbackInfo <v8 :: Value> const & info, int argc, Statement * stmt)
-#line 160 "./src/util/binder.lzz"
+#line 165 "./src/util/binder.lzz"
                                                                         {
                 v8 :: Isolate * isolate = info . GetIsolate ( ) ;
                 int count = 0;

--- a/src/better_sqlite3.hpp
+++ b/src/better_sqlite3.hpp
@@ -757,22 +757,24 @@ private:
 #line 55 "./src/util/binder.lzz"
   void Fail (void (* Throw) (char const *), char const * message);
 #line 63 "./src/util/binder.lzz"
+  bool IsAnonIndex (int index);
+#line 68 "./src/util/binder.lzz"
   int NextAnonIndex ();
-#line 69 "./src/util/binder.lzz"
+#line 74 "./src/util/binder.lzz"
   void BindValue (v8::Isolate * isolate, v8::Local <v8::Value> value, int index);
-#line 90 "./src/util/binder.lzz"
+#line 95 "./src/util/binder.lzz"
   int BindArray (v8::Isolate * isolate, v8::Local <v8::Array> arr);
-#line 116 "./src/util/binder.lzz"
+#line 121 "./src/util/binder.lzz"
   int BindObject (v8::Isolate * isolate, v8::Local <v8::Object> obj, Statement * stmt);
-#line 160 "./src/util/binder.lzz"
+#line 165 "./src/util/binder.lzz"
   Result BindArgs (v8::FunctionCallbackInfo <v8 :: Value> const & info, int argc, Statement * stmt);
-#line 200 "./src/util/binder.lzz"
+#line 205 "./src/util/binder.lzz"
   sqlite3_stmt * handle;
-#line 201 "./src/util/binder.lzz"
+#line 206 "./src/util/binder.lzz"
   int param_count;
-#line 202 "./src/util/binder.lzz"
+#line 207 "./src/util/binder.lzz"
   int anon_index;
-#line 203 "./src/util/binder.lzz"
+#line 208 "./src/util/binder.lzz"
   bool success;
 };
 #line 34 "./src/better_sqlite3.lzz"

--- a/src/objects/statement.lzz
+++ b/src/objects/statement.lzz
@@ -29,7 +29,7 @@ public:
 		int param_count = sqlite3_bind_parameter_count(handle);
 		for (int i = 1; i <= param_count; ++i) {
 			const char* name = sqlite3_bind_parameter_name(handle, i);
-			if (name != NULL) bind_map->Add(isolate, name + 1, i);
+			if (name != NULL && name[0] != '?') bind_map->Add(isolate, name + 1, i);
 		}
 		has_bind_map = true;
 		return bind_map;

--- a/src/util/binder.lzz
+++ b/src/util/binder.lzz
@@ -60,8 +60,13 @@ private:
 		success = false;
 	}
 
+	bool IsAnonIndex(int index) {
+		const char* name = sqlite3_bind_parameter_name(handle, index);
+		return name == NULL || name[0] == '?';
+	}
+
 	int NextAnonIndex() {
-		while (sqlite3_bind_parameter_name(handle, ++anon_index) != NULL) {}
+		while (!IsAnonIndex(++anon_index)) {}
 		return anon_index;
 	}
 

--- a/test/20.statement.run.js
+++ b/test/20.statement.run.js
@@ -115,6 +115,9 @@ describe('Statement#run()', function () {
 		this.db.prepare('INSERT INTO entries VALUES (?, ?, ?, ?)').run('foo', 25, 25, Buffer.alloc(8).fill(0xdd));
 		this.db.prepare('INSERT INTO entries VALUES (?, ?, ?, ?)').run(['foo', 25, 25, Buffer.alloc(8).fill(0xdd)]);
 		this.db.prepare('INSERT INTO entries VALUES (?, ?, ?, ?)').run(['foo', 25], [25], Buffer.alloc(8).fill(0xdd));
+		this.db.prepare('INSERT INTO entries VALUES (?4, ?3, ?2, ?1)').run(Buffer.alloc(8).fill(0xdd), 25, 25, 'foo');
+		this.db.prepare('INSERT INTO entries VALUES (?, ?, ?2, ?)').run('foo', 25, Buffer.alloc(8).fill(0xdd));
+		this.db.prepare('INSERT INTO entries VALUES (?1, ?2, ?4, ?5)').run('foo', 25, null, 25, Buffer.alloc(8).fill(0xdd));
 		this.db.prepare('INSERT INTO entries VALUES (@a, @b, @c, @d)').run({ a: 'foo', b: 25, c: 25, d: Buffer.alloc(8).fill(0xdd) });
 		this.db.prepare('INSERT INTO entries VALUES ($a, $b, $c, $d)').run({ a: 'foo', b: 25, c: 25, d: Buffer.alloc(8).fill(0xdd) });
 		this.db.prepare('INSERT INTO entries VALUES (:a, :b, :c, :d)').run({ a: 'foo', b: 25, c: 25, d: Buffer.alloc(8).fill(0xdd) });
@@ -165,6 +168,6 @@ describe('Statement#run()', function () {
 		while (row = this.db.prepare(`SELECT * FROM entries WHERE rowid=${++i}`).get()) {
 			expect(row).to.deep.equal({ a: 'foo', b: 25, c: 25, d: Buffer.alloc(8).fill(0xdd) });
 		}
-		expect(i).to.equal(11);
+		expect(i).to.equal(14);
 	});
 });


### PR DESCRIPTION
Parameters of the form `?1`, `?2`, etc aren't named parameters, you're explicitly specifying the parameter index, allowing indexed (i.e. unnamed) parameters to be explicitly ordered, reused, or skipped. Somewhat oddly however sqlite still reports their name* from `sqlite3_bind_parameter_name`, causing better-sqlite3 to force it to be passed by name which is not what's expected or desired.

(* or rather their _first_ name, e.g. `SELECT ?01, ?1, ?001` has a single parameter whose reported name is `?01` though I don't think sqlite documents which of the three names is returned in this case.)

This patch-set fixes this and adds some tests for explicitly numbered parameters (there were none whatsoever).

The reason I care about explicitly numbered parameters is because I'm using tagged templates for queries, and using explicit numbering allows this to be much more robust against e.g. parts of the query being comments out. Here's a highly simplified minimalistic demo of this concept:
```javascript
class Database extends require('better-sqlite3') {
	#compiled = new WeakMap;
	compile( tmpl ) {
		let stmt = this.#compiled.get( tmpl );
		if( stmt )
			return stmt;
		let sql = '';
		tmpl.forEach( (chunk, i) => {
			if (i) sql += ` ?${i} `;
			sql += chunk;
		});
		console.log(`COMPILING: \x1b[2m${sql.trim()}\x1b[m`);
		stmt = this.prepare( sql );
		this.#compiled.set( tmpl, stmt );
		return stmt;
	}
	get( tmpl, ...args ) {  return this.compile( tmpl ).get( ...args );  }
}

let db = new Database(':memory:');
function demo( a, b ) {
	return db.get`SELECT ${a} as a, ${b} as b`;
}
console.log( demo( 1, 2 ) );
console.log( demo( 'foo', 'bar' ) );

function demo2( a, b, c ) {
	return db.get`
		SELECT ${a} as a,
		--	${b} as b,  -- FIXME can we get rid of this?
			${c} as c`;
}
console.log( demo2( 1, 2, 3 ) );
console.log( demo2( 'foo', 'bar', 'baz' ) );
```
output:
```text
COMPILING: SELECT  ?1  as a,  ?2  as b
{ a: 1, b: 2 }
{ a: 'foo', b: 'bar' }
COMPILING: SELECT  ?1  as a,
                --       ?2  as b,  -- FIXME can we get rid of this?
                         ?3  as c
{ a: 1, c: 3 }
{ a: 'foo', c: 'baz' }
```