### PR TITLE
Fix db::serialize() crashing with Electron

### DIFF
--- a/src/objects/database.lzz
+++ b/src/objects/database.lzz
@@ -290,7 +290,7 @@ private:
 		}
 
 		info.GetReturnValue().Set(
-			node::Buffer::New(isolate, reinterpret_cast<char*>(data), length, FreeSerialization, NULL).ToLocalChecked()
+			SAFE_NEW_BUFFER(isolate, reinterpret_cast<char*>(data), length, FreeSerialization, NULL).ToLocalChecked()
 		);
 	}
 

--- a/src/util/macros.lzz
+++ b/src/util/macros.lzz
@@ -156,3 +156,16 @@ void SetPrototypeGetter(
 		v8::PropertyAttribute::None
 	);
 }
+
+#src
+#ifndef V8_COMPRESS_POINTERS_IN_SHARED_CAGE
+#	define SAFE_NEW_BUFFER(env, data, length, finalizeCallback, finalizeHint) node::Buffer::New(env, data, length, finalizeCallback, finalizeHint)
+#else
+	static inline v8::MaybeLocal<v8::Object> BufferSandboxNew(v8::Isolate* isolate, char* data, size_t length, void (*finalizeCallback)(char*, void*), void* finalizeHint) {
+			v8::MaybeLocal<v8::Object> buffer = node::Buffer::Copy(isolate, data, length); 
+			finalizeCallback(data, finalizeHint);
+			return buffer;
+	}
+#	define SAFE_NEW_BUFFER(env, data, length, finalizeCallback, finalizeHint) BufferSandboxNew(env, data, length, finalizeCallback, finalizeHint)
+#endif
+#end


### PR DESCRIPTION
This is a fix for #981

It use a #ifdef encapsulation to only use the copy method on electron build.

This is the first time I use lzz and I did not achieve to output #ifndef/else/endif clause from the database.lzz file, so I use the macro.lzz instead. I hope this is acceptable :).