### PR TITLE
update prebuild and remove node-gyp version override

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,16 +24,10 @@
     "cli-color": "^2.0.3",
     "fs-extra": "^11.1.1",
     "mocha": "^10.2.0",
-    "node-gyp": "9.4.0",
     "nodemark": "^0.3.0",
-    "prebuild": "^11.0.4",
+    "prebuild": "^12.0.0",
     "sqlite": "^5.0.1",
     "sqlite3": "^5.1.6"
-  },
-  "overrides": {
-    "prebuild": {
-      "node-gyp": "$node-gyp"
-    }
   },
   "scripts": {
     "install": "prebuild-install || node-gyp rebuild --release",


### PR DESCRIPTION
Since prebuild has updated it's dependency to the latest node-gyp version 9.4.0, the version override may no longer be required.