### PR TITLE
Stop building and testing against Node `v16` (runtime EOL)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   NODE_BUILD_CMD: npx --no-install prebuild -r node -t 18.0.0 -t 20.0.0 --include-regex 'better_sqlite3.node$'
-  ELECTRON_BUILD_CMD: npx --no-install prebuild -r electron -t 23.0.0 -t 24.0.0 -t 25.0.0 -t 26.0.0 --include-regex 'better_sqlite3.node$'
+  ELECTRON_BUILD_CMD: npx --no-install prebuild -r electron -t 16.0.0 -t 17.0.0 -t 18.0.0 -t 19.0.0 -t 20.0.0 -t 21.0.0 -t 22.0.0 -t 23.0.0 -t 24.0.0 -t 25.0.0 -t 26.0.0 -t 27.0.0 --include-regex 'better_sqlite3.node$'
 
 jobs:
   test:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,8 @@ on:
   workflow_dispatch: {}
 
 env:
-  NODE_BUILD_CMD: npx --no-install prebuild -r node -t 16.0.0 -t 18.0.0 -t 20.0.0 --include-regex 'better_sqlite3.node$'
-  ELECTRON_BUILD_CMD: npx --no-install prebuild -r electron -t 16.0.0 -t 17.0.0 -t 18.0.0 -t 19.0.0 -t 20.0.0 -t 21.0.0 -t 22.0.0 -t 23.0.0 -t 24.0.0 -t 25.0.0 -t 26.0.0 --include-regex 'better_sqlite3.node$'
+  NODE_BUILD_CMD: npx --no-install prebuild -r node -t 18.0.0 -t 20.0.0 --include-regex 'better_sqlite3.node$'
+  ELECTRON_BUILD_CMD: npx --no-install prebuild -r electron -t 23.0.0 -t 24.0.0 -t 25.0.0 -t 26.0.0 --include-regex 'better_sqlite3.node$'
 
 jobs:
   test:
@@ -25,7 +25,6 @@ jobs:
           - macos-latest
           - windows-2019
         node:
-          - 16
           - 18
           - 20
     name: Testing Node ${{ matrix.node }} on ${{ matrix.os }}


### PR DESCRIPTION
Node `v16` reached its EOL today. It's better not to build for unsupported runtimes on future releases.

This also removes building for Electron versions that ship with Node `v16`. This might seem a bit extreme but this limits a lot of issues in building going forward _(like we faced in the past)_. It also significantly reduces the build time in releases. It already feels too much.