### PR TITLE
fix: support passing `file://` URI when using custom-compile SQLite

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -61,7 +61,7 @@ function Database(filenameGiven, options) {
 	}
 
 	// Make sure the specified directory exists
-	if (!anonymous && !fs.existsSync(path.dirname(filename))) {
+	if (!filename.startsWith('file://') && !anonymous && !fs.existsSync(path.dirname(filename))) {
 		throw new TypeError('Cannot open database because the directory does not exist');
 	}
 


### PR DESCRIPTION
I'm trying to use `better-sqlite3` with an SQLite that is compiled with `SQLITE_USE_URI=1`:

```js
const db = SQLite(`file:///foo/bar?vfs=myfs&mode=ro&immutable=1`);
```

This, however, doesn't work right now, since there's an erroneous assertion in the database creation.

With this patch, I can successfully connect to the database.

References https://github.com/WiseLibs/better-sqlite3/issues/483