### PR TITLE
Build `arm` based macOS builds natively

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,7 @@ jobs:
         os:
           - ubuntu-20.04
           - macos-latest
+          - macos-14
           - windows-2019
     name: Prebuild on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -84,10 +85,6 @@ jobs:
         run: |
           ${{ env.NODE_BUILD_CMD }} --arch ia32 -u ${{ secrets.GITHUB_TOKEN }}
           ${{ env.ELECTRON_BUILD_CMD }} --arch ia32 -u ${{ secrets.GITHUB_TOKEN }}
-      - if: matrix.os == 'macos-latest'
-        run: |
-          ${{ env.NODE_BUILD_CMD }} --arch arm64 -u ${{ secrets.GITHUB_TOKEN }}
-          ${{ env.ELECTRON_BUILD_CMD }} --arch arm64 -u ${{ secrets.GITHUB_TOKEN }}
 
   prebuild-alpine:
     name: Prebuild on alpine


### PR DESCRIPTION
Now that [GitHub officially has an M1 macOS runner](https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/) available, it's much better to build arm builds natively on the `macos-14` runner. Results in way faster and much more stable builds. Completes in about 4 minutes compared to the previous 10 minutes. All of the prebuilds currently supported by BS3 were tested on this runner at [`better-sqlite3-multiple-ciphers`](https://github.com/m4heshd/better-sqlite3-multiple-ciphers).

- [**Node build logs**](https://github.com/m4heshd/better-sqlite3-multiple-ciphers/actions/runs/7807635689/job/21296387383)
- [**Electron build logs**](https://github.com/m4heshd/better-sqlite3-multiple-ciphers/actions/runs/7807640326/job/21296402646)

It might also be possible to build emulated builds _(arm64 on Linux)_ on this runner much faster, together with Docker buildx. I'll look into that also, as soon as I have some time.