### PR TITLE
Add support for Windows `arm64` prebuilds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,9 @@ jobs:
       - if: matrix.os == 'windows-2019'
         run: |
           ${{ env.NODE_BUILD_CMD }} --arch ia32 -u ${{ secrets.GITHUB_TOKEN }}
+          npx --no-install prebuild -r node -t 20.0.0 -t 21.0.0 --include-regex 'better_sqlite3.node$' --arch arm64 -u ${{ secrets.GITHUB_TOKEN }}
           ${{ env.ELECTRON_BUILD_CMD }} --arch ia32 -u ${{ secrets.GITHUB_TOKEN }}
+          ${{ env.ELECTRON_BUILD_CMD }} --arch arm64 -u ${{ secrets.GITHUB_TOKEN }}
 
   prebuild-alpine:
     name: Prebuild on alpine


### PR DESCRIPTION
This seems to be becoming a necessity now since Windows is getting popular on arm64 devices.

All of the supported runtime versions were tested at [`better-sqlite3-multiple-ciphers` (successful workflow run)](https://github.com/m4heshd/better-sqlite3-multiple-ciphers/actions/runs/7853495517).

🟡 As seen in the diff, Node arm64 build needed a custom command since there aren't any official Windows arm64 headers available for Node till Node v20 (https://nodejs.org/dist/v20.0.0). So for the moment, we can only build against Windows arm64 for Node v20 upwards. We can clean up the build process once Node v18 has reached EOL.