### PR TITLE
Support builds for Electron v29

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   NODE_BUILD_CMD: npx --no-install prebuild -r node -t 18.0.0 -t 20.0.0 -t 21.0.0 --include-regex 'better_sqlite3.node$'
-  ELECTRON_BUILD_CMD: npx --no-install prebuild -r electron -t 16.0.0 -t 17.0.0 -t 18.0.0 -t 19.0.0 -t 20.0.0 -t 21.0.0 -t 22.0.0 -t 23.0.0 -t 24.0.0 -t 25.0.0 -t 26.0.0 -t 27.0.0 -t 28.0.0 --include-regex 'better_sqlite3.node$'
+  ELECTRON_BUILD_CMD: npx --no-install prebuild -r electron -t 16.0.0 -t 17.0.0 -t 18.0.0 -t 19.0.0 -t 20.0.0 -t 21.0.0 -t 22.0.0 -t 23.0.0 -t 24.0.0 -t 25.0.0 -t 26.0.0 -t 27.0.0 -t 28.0.0 -t 29.0.0 --include-regex 'better_sqlite3.node$'
 
 jobs:
   test:

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "fs-extra": "^11.1.1",
     "mocha": "^10.2.0",
     "nodemark": "^0.3.0",
-    "prebuild": "^12.0.0",
+    "prebuild": "^13.0.0",
     "sqlite": "^5.0.1",
     "sqlite3": "^5.1.6"
   },

--- a/src/better_sqlite3.cpp
+++ b/src/better_sqlite3.cpp
@@ -2,7 +2,35 @@
 //
 
 #include "better_sqlite3.hpp"
-#line 161 "./src/util/macros.lzz"
+#line 153 "./src/util/macros.lzz"
+void SetPrototypeGetter(
+	v8::Isolate* isolate,
+	v8::Local<v8::External> data,
+	v8::Local<v8::FunctionTemplate> recv,
+	const char* name,
+	v8::AccessorGetterCallback func
+) {
+	v8::HandleScope scope(isolate);
+	
+	#if defined NODE_MODULE_VERSION && NODE_MODULE_VERSION < 121
+	recv->InstanceTemplate()->SetAccessor(
+		InternalizedFromLatin1(isolate, name),
+		func,
+		0,
+		data,
+		v8::AccessControl::DEFAULT,
+		v8::PropertyAttribute::None
+	);
+	#else
+	recv->InstanceTemplate()->SetAccessor(
+		InternalizedFromLatin1(isolate, name),
+		func,
+		0,
+		data
+	);
+	#endif
+}
+#line 183 "./src/util/macros.lzz"
 #ifndef V8_COMPRESS_POINTERS_IN_SHARED_CAGE
 #define SAFE_NEW_BUFFER(env, data, length, finalizeCallback, finalizeHint) node::Buffer::New(env, data, length, finalizeCallback, finalizeHint)
 #else
@@ -117,20 +145,6 @@ void SetPrototypeSymbolMethod (v8::Isolate * isolate, v8::Local <v8::External> d
         recv->PrototypeTemplate()->Set(
                 symbol,
                 v8::FunctionTemplate::New(isolate, func, data, v8::Signature::New(isolate, recv))
-        );
-}
-#line 142 "./src/util/macros.lzz"
-void SetPrototypeGetter (v8::Isolate * isolate, v8::Local <v8::External> data, v8::Local <v8::FunctionTemplate> recv, char const * name, v8::AccessorGetterCallback func)
-#line 148 "./src/util/macros.lzz"
-  {
-        v8::HandleScope scope(isolate);
-        recv->InstanceTemplate()->SetAccessor(
-                InternalizedFromLatin1(isolate, name),
-                func,
-                0,
-                data,
-                v8::AccessControl::DEFAULT,
-                v8::PropertyAttribute::None
         );
 }
 #line 4 "./src/util/constants.lzz"

--- a/src/better_sqlite3.hpp
+++ b/src/better_sqlite3.hpp
@@ -18,6 +18,14 @@
 #include <node_buffer.h>
 #line 31 "./src/util/macros.lzz"
 template <class T> using CopyablePersistent = v8::Persistent<T, v8::CopyablePersistentTraits<T>>;
+#line 144 "./src/util/macros.lzz"
+void SetPrototypeGetter(
+	v8::Isolate* isolate,
+	v8::Local<v8::External> data,
+	v8::Local<v8::FunctionTemplate> recv,
+	const char* name,
+	v8::AccessorGetterCallback func
+);
 #line 36 "./src/util/binder.lzz"
 	static bool IsPlainObject(v8::Isolate* isolate, v8::Local<v8::Object> obj);
 #define LZZ_INLINE inline
@@ -53,8 +61,6 @@ v8::Local <v8::FunctionTemplate> NewConstructorTemplate (v8::Isolate * isolate, 
 void SetPrototypeMethod (v8::Isolate * isolate, v8::Local <v8::External> data, v8::Local <v8::FunctionTemplate> recv, char const * name, v8::FunctionCallback func);
 #line 129 "./src/util/macros.lzz"
 void SetPrototypeSymbolMethod (v8::Isolate * isolate, v8::Local <v8::External> data, v8::Local <v8::FunctionTemplate> recv, v8::Local <v8::Symbol> symbol, v8::FunctionCallback func);
-#line 142 "./src/util/macros.lzz"
-void SetPrototypeGetter (v8::Isolate * isolate, v8::Local <v8::External> data, v8::Local <v8::FunctionTemplate> recv, char const * name, v8::AccessorGetterCallback func);
 #line 1 "./src/util/constants.lzz"
 class CS
 {

--- a/src/util/macros.lzz
+++ b/src/util/macros.lzz
@@ -139,6 +139,17 @@ void SetPrototypeSymbolMethod(
 		v8::FunctionTemplate::New(isolate, func, data, v8::Signature::New(isolate, recv))
 	);
 }
+
+#hdr
+void SetPrototypeGetter(
+	v8::Isolate* isolate,
+	v8::Local<v8::External> data,
+	v8::Local<v8::FunctionTemplate> recv,
+	const char* name,
+	v8::AccessorGetterCallback func
+);
+#end
+#src 
 void SetPrototypeGetter(
 	v8::Isolate* isolate,
 	v8::Local<v8::External> data,
@@ -147,6 +158,8 @@ void SetPrototypeGetter(
 	v8::AccessorGetterCallback func
 ) {
 	v8::HandleScope scope(isolate);
+	
+	#if defined NODE_MODULE_VERSION && NODE_MODULE_VERSION < 121
 	recv->InstanceTemplate()->SetAccessor(
 		InternalizedFromLatin1(isolate, name),
 		func,
@@ -155,7 +168,16 @@ void SetPrototypeGetter(
 		v8::AccessControl::DEFAULT,
 		v8::PropertyAttribute::None
 	);
+	#else
+	recv->InstanceTemplate()->SetAccessor(
+		InternalizedFromLatin1(isolate, name),
+		func,
+		0,
+		data
+	);
+	#endif
 }
+#end
 
 #src
 #ifndef V8_COMPRESS_POINTERS_IN_SHARED_CAGE


### PR DESCRIPTION
This branch adds some adjustments in order to enable builds for Electron v29. The signature of ```SetAccessor``` has been adjusted to be the same as before for all versions below 29. For 29 and up the new function signature will be used.