### PR TITLE
Clarify error handling behavior for nested transactions in docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -72,6 +72,8 @@ insertMany([
 
 Transaction functions can be called from inside other transaction functions. When doing so, the inner transaction becomes a [savepoint](https://www.sqlite.org/lang_savepoint.html).
 
+If an error is thrown inside of a nested transaction function, the nested transaction function will roll back to the state just before the savepoint and rethrow the error. If the error is not caught in the outer transaction function, this will cause the outer transaction function to roll back as well.
+
 ```js
 const newExpense = db.prepare('INSERT INTO expenses (note, dollars) VALUES (?, ?)');
 


### PR DESCRIPTION
I spent two hours reading the SQLite documentation and the better-sqlite3 source code. Thought this might help other people as well.

Thanks for the great library!