### PR TITLE
Fix python setuptools on macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,10 +38,10 @@ jobs:
           node-version: ${{ matrix.node }}
       - if: ${{ startsWith(matrix.os, 'windows') }}
         run: pip.exe install setuptools
-      - if: ${{ ! startsWith(matrix.os, 'windows') && matrix.os != 'macos-14' }}
+      - if: ${{ startsWith(matrix.os, 'macos') }}
+        run: brew install python-setuptools
+      - if: ${{ !startsWith(matrix.os, 'windows') && !startsWith(matrix.os, 'macos') }}
         run: python3 -m pip install setuptools
-      - if: matrix.os == 'macos-14'
-        run: python3 -m pip install --break-system-packages setuptools
       - run: npm install --ignore-scripts
       - run: npm run build-debug
       - run: npm test
@@ -85,10 +85,10 @@ jobs:
           node-version: 16
       - if: ${{ startsWith(matrix.os, 'windows') }}
         run: pip.exe install setuptools
-      - if: ${{ ! startsWith(matrix.os, 'windows') && matrix.os != 'macos-14' }}
+      - if: ${{ startsWith(matrix.os, 'macos') }}
+        run: brew install python-setuptools
+      - if: ${{ !startsWith(matrix.os, 'windows') && !startsWith(matrix.os, 'macos') }}
         run: python3 -m pip install setuptools
-      - if: matrix.os == 'macos-14'
-        run: python3 -m pip install --break-system-packages setuptools
       - run: npm install --ignore-scripts
       - run: ${{ env.NODE_BUILD_CMD }} -u ${{ secrets.GITHUB_TOKEN }}
       - run: ${{ env.ELECTRON_BUILD_CMD }} -u ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
@JoshuaWise this should fix the current build failure on `master`.

Fixes https://github.com/WiseLibs/better-sqlite3/actions/runs/8853339888/job/24313966887

1. the `if` clauses didn't capture `macos-latest` and `macos-14` properly
2. let's use `brew install python-setuptools` instead of `--break-system-packages`.

NOTE: it'd be ideal if we could extract this as a setup task to eliminate the code duplication here, but I didn't want to make the diff bigger. Holler if you'd prefer that.