### PR TITLE
Add Node.js v22. Drop ancient EOL versions of Node.js and Electron

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,12 @@ on:
   workflow_dispatch: {}
 
 env:
-  NODE_BUILD_CMD: npx --no-install prebuild -r node -t 18.0.0 -t 20.0.0 -t 21.0.0 --include-regex 'better_sqlite3.node$'
-  ELECTRON_BUILD_CMD: npx --no-install prebuild -r electron -t 16.0.0 -t 17.0.0 -t 18.0.0 -t 19.0.0 -t 20.0.0 -t 21.0.0 -t 22.0.0 -t 23.0.0 -t 24.0.0 -t 25.0.0 -t 26.0.0 -t 27.0.0 -t 28.0.0 -t 29.0.0 -t 30.0.0 --include-regex 'better_sqlite3.node$'
+  # See https://nodejs.org/en/about/previous-releases
+  # Node.js 16 EOL = 11 Sep 2023
+  NODE_BUILD_CMD: npx --no-install prebuild -r node -t 18.0.0 -t 20.0.0 -t 21.0.0 -t 22.0.0 --include-regex 'better_sqlite3.node$'
+  # See https://www.electronjs.org/docs/latest/tutorial/electron-timelines#version-support-policy
+  # The v25 EOL = 2023-dec-5. v26 EOL = 2024-feb-20. v27 EOL = 2024-apr-16. v28 EOL = 2024-jun-11. v29 EOL = 2024-aug-20.
+  ELECTRON_BUILD_CMD: npx --no-install prebuild -r electron -t 25.0.0 -t 26.0.0 -t 27.0.0 -t 28.0.0 -t 29.0.0 -t 30.0.0 --include-regex 'better_sqlite3.node$'
 
 jobs:
   test:
@@ -29,6 +33,7 @@ jobs:
           - 18
           - 20
           - 21
+          - 22
     name: Testing Node ${{ matrix.node }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
@@ -61,7 +66,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
           registry-url: https://registry.npmjs.org
       - run: npm publish
         env:
@@ -82,7 +87,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
       - if: ${{ startsWith(matrix.os, 'windows') }}
         run: pip.exe install setuptools
       - if: ${{ ! startsWith(matrix.os, 'windows') && matrix.os != 'macos-14' }}
@@ -102,7 +107,7 @@ jobs:
   prebuild-alpine:
     name: Prebuild on alpine
     runs-on: ubuntu-latest
-    container: node:16-alpine
+    container: node:18-alpine
     needs: publish
     steps:
       - uses: actions/checkout@v4
@@ -123,7 +128,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3
       - run: |
-          docker run --rm -v $(pwd):/tmp/project --entrypoint /bin/sh --platform linux/${{ matrix.arch }} node:16-alpine -c "\
+          docker run --rm -v $(pwd):/tmp/project --entrypoint /bin/sh --platform linux/${{ matrix.arch }} node:18-alpine -c "\
           apk add build-base git python3 py3-setuptools --update-cache && \
           cd /tmp/project && \
           npm install --ignore-scripts && \
@@ -142,7 +147,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3
       - run: |
-          docker run --rm -v $(pwd):/tmp/project --entrypoint /bin/sh --platform linux/${{ matrix.arch }} node:16 -c "\
+          docker run --rm -v $(pwd):/tmp/project --entrypoint /bin/sh --platform linux/${{ matrix.arch }} node:18 -c "\
           cd /tmp/project && \
           npm install --ignore-scripts && \
           ${{ env.NODE_BUILD_CMD }} -u ${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
       - name: Configure user
         run: |
           git config --local user.name "${{ github.actor }}"

--- a/.github/workflows/update-sqlite.yml
+++ b/.github/workflows/update-sqlite.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
       - name: Create new update branch
         run: git checkout -b sqlite-update-${{ env.ENV_VERSION }}
       - name: Update download script


### PR DESCRIPTION
We've got a ton of ancient versions in here, and we're building on a version of Node.js that EOL'ed more than 6 months ago.

I've culled versions that EOL'ed more than 6 months ago, which should speed up build times. I also added Node.js v22.

This PR requires the next build be a major version.
