### PR TITLE
Support builds for Electron v31

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ env:
   NO_V18_NODE_BUILD_CMD: npx --no-install prebuild -r node -t 20.0.0 -t 22.0.0 --include-regex 'better_sqlite3.node$'
   # See https://www.electronjs.org/docs/latest/tutorial/electron-timelines#version-support-policy
   # Electron v25 EOL = 2023-12-05. v26 EOL = 2024-02-20. v27 EOL = 2024-04-16. v28 EOL = 2024-06-11. v29 EOL = 2024-08-20.
-  ELECTRON_BUILD_CMD: npx --no-install prebuild -r electron -t 26.0.0 -t 27.0.0 -t 28.0.0 -t 29.0.0 -t 30.0.0 --include-regex 'better_sqlite3.node$'
+  ELECTRON_BUILD_CMD: npx --no-install prebuild -r electron -t 26.0.0 -t 27.0.0 -t 28.0.0 -t 29.0.0 -t 30.0.0 -t 31.0.0 --include-regex 'better_sqlite3.node$'
 
 jobs:
   test:

--- a/src/better_sqlite3.hpp
+++ b/src/better_sqlite3.hpp
@@ -17,7 +17,7 @@
 #include <node_object_wrap.h>
 #include <node_buffer.h>
 #line 31 "./src/util/macros.lzz"
-template <class T> using CopyablePersistent = v8::Persistent<T, v8::CopyablePersistentTraits<T>>;
+template <class T> using CopyablePersistent = v8::Global<T>;
 #line 144 "./src/util/macros.lzz"
 void SetPrototypeGetter(
 	v8::Isolate* isolate,

--- a/src/util/macros.lzz
+++ b/src/util/macros.lzz
@@ -28,7 +28,7 @@ inline v8::Local<v8::String> InternalizedFromLatin1(v8::Isolate* isolate, const 
 }
 
 #hdr
-template <class T> using CopyablePersistent = v8::Persistent<T, v8::CopyablePersistentTraits<T>>;
+template <class T> using CopyablePersistent = v8::Global<T>;
 #end
 inline void SetFrozen(v8::Isolate* isolate, v8::Local<v8::Context> ctx, v8::Local<v8::Object> obj, CopyablePersistent<v8::String>& key, v8::Local<v8::Value> value) {
 	obj->DefineOwnProperty(ctx, key.Get(isolate), value, static_cast<v8::PropertyAttribute>(v8::DontDelete | v8::ReadOnly)).FromJust();


### PR DESCRIPTION
Replaced deprecated v8::CopyablePersistentTraits with v8::Global to enabled builds for Electron v31.