### PR TITLE
Fix macOS x64 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04
-          - macos-latest
+          - macos-13
           - macos-14
           - windows-2019
         node:
@@ -84,7 +84,7 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04
-          - macos-latest
+          - macos-13
           - macos-14
           - windows-2019
     name: Prebuild on ${{ matrix.os }}


### PR DESCRIPTION
The `macos-latest` runner label has [been migrated](https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/) to `macos-14` which means the build workflow will try to build for ARM64 macs twice. This will restore the previous build process.