### PR TITLE
Support builds for Electron v32

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,11 @@ jobs:
         run: brew install python-setuptools
       - if: ${{ !startsWith(matrix.os, 'windows') && !startsWith(matrix.os, 'macos') }}
         run: python3 -m pip install setuptools
+      - if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        run: |
+          sudo apt update
+          sudo apt install gcc-10 g++-10 -y
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ g++ /usr/bin/g++-10 --slave /usr/bin/gcov gcov /usr/bin/gcov-10
       - run: npm install --ignore-scripts
       - run: npm run build-debug
       - run: npm test
@@ -101,6 +106,11 @@ jobs:
         run: brew install python-setuptools
       - if: ${{ !startsWith(matrix.os, 'windows') && !startsWith(matrix.os, 'macos') }}
         run: python3 -m pip install setuptools
+      - if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        run: |
+          sudo apt update
+          sudo apt install gcc-10 g++-10 -y
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ g++ /usr/bin/g++-10 --slave /usr/bin/gcov gcov /usr/bin/gcov-10
       - run: npm install --ignore-scripts
       - run: ${{ env.NODE_BUILD_CMD }} -u ${{ secrets.GITHUB_TOKEN }}
       - run: ${{ env.ELECTRON_BUILD_CMD }} -u ${{ secrets.GITHUB_TOKEN }}

--- a/binding.gyp
+++ b/binding.gyp
@@ -9,14 +9,14 @@
       'target_name': 'better_sqlite3',
       'dependencies': ['deps/sqlite3.gyp:sqlite3'],
       'sources': ['src/better_sqlite3.cpp'],
-      'cflags_cc': ['-std=c++17'],
+      'cflags_cc': ['-std=c++20'],
       'xcode_settings': {
-        'OTHER_CPLUSPLUSFLAGS': ['-std=c++17', '-stdlib=libc++'],
+        'OTHER_CPLUSPLUSFLAGS': ['-std=c++20', '-stdlib=libc++'],
       },
       'msvs_settings': {
         'VCCLCompilerTool': {
           'AdditionalOptions': [
-            '/std:c++17',
+            '/std:c++20',
           ],
         },
       },

--- a/src/better_sqlite3.cpp
+++ b/src/better_sqlite3.cpp
@@ -2,7 +2,7 @@
 //
 
 #include "better_sqlite3.hpp"
-#line 150 "./src/util/macros.lzz"
+#line 154 "./src/util/macros.lzz"
 void SetPrototypeGetter(
 	v8::Isolate* isolate,
 	v8::Local<v8::External> data,
@@ -13,7 +13,7 @@ void SetPrototypeGetter(
 	v8::HandleScope scope(isolate);
 
 	#if defined NODE_MODULE_VERSION && NODE_MODULE_VERSION < 121
-	recv->InstanceTemplate()->SetNativeDataProperty(
+	recv->InstanceTemplate()->SetAccessor(
 		InternalizedFromLatin1(isolate, name),
 		func,
 		0,
@@ -30,7 +30,7 @@ void SetPrototypeGetter(
 	);
 	#endif
 }
-#line 180 "./src/util/macros.lzz"
+#line 184 "./src/util/macros.lzz"
 #ifndef V8_COMPRESS_POINTERS_IN_SHARED_CAGE
 #define SAFE_NEW_BUFFER(env, data, length, finalizeCallback, finalizeHint) node::Buffer::New(env, data, length, finalizeCallback, finalizeHint)
 #else
@@ -103,33 +103,33 @@ namespace Data
 #line 70 "./src/util/data.lzz"
   static char const RAW = 3;
 }
-#line 34 "./src/util/macros.lzz"
+#line 38 "./src/util/macros.lzz"
 void ThrowError (char const * message)
-#line 34 "./src/util/macros.lzz"
+#line 38 "./src/util/macros.lzz"
                                      { v8 :: Isolate * isolate = v8 :: Isolate :: GetCurrent ( ) ; isolate->ThrowException(v8::Exception::Error(StringFromUtf8(isolate, message, -1)));
 }
-#line 35 "./src/util/macros.lzz"
+#line 39 "./src/util/macros.lzz"
 void ThrowTypeError (char const * message)
-#line 35 "./src/util/macros.lzz"
+#line 39 "./src/util/macros.lzz"
                                          { v8 :: Isolate * isolate = v8 :: Isolate :: GetCurrent ( ) ; isolate->ThrowException(v8::Exception::TypeError(StringFromUtf8(isolate, message, -1)));
 }
-#line 36 "./src/util/macros.lzz"
+#line 40 "./src/util/macros.lzz"
 void ThrowRangeError (char const * message)
-#line 36 "./src/util/macros.lzz"
+#line 40 "./src/util/macros.lzz"
                                           { v8 :: Isolate * isolate = v8 :: Isolate :: GetCurrent ( ) ; isolate->ThrowException(v8::Exception::RangeError(StringFromUtf8(isolate, message, -1)));
 }
-#line 102 "./src/util/macros.lzz"
+#line 106 "./src/util/macros.lzz"
 v8::Local <v8::FunctionTemplate> NewConstructorTemplate (v8::Isolate * isolate, v8::Local <v8::External> data, v8::FunctionCallback func, char const * name)
-#line 107 "./src/util/macros.lzz"
+#line 111 "./src/util/macros.lzz"
   {
         v8::Local<v8::FunctionTemplate> t = v8::FunctionTemplate::New(isolate, func, data);
         t->InstanceTemplate()->SetInternalFieldCount(1);
         t->SetClassName(InternalizedFromLatin1(isolate, name));
         return t;
 }
-#line 113 "./src/util/macros.lzz"
+#line 117 "./src/util/macros.lzz"
 void SetPrototypeMethod (v8::Isolate * isolate, v8::Local <v8::External> data, v8::Local <v8::FunctionTemplate> recv, char const * name, v8::FunctionCallback func)
-#line 119 "./src/util/macros.lzz"
+#line 123 "./src/util/macros.lzz"
   {
         v8::HandleScope scope(isolate);
         recv->PrototypeTemplate()->Set(
@@ -137,9 +137,9 @@ void SetPrototypeMethod (v8::Isolate * isolate, v8::Local <v8::External> data, v
                 v8::FunctionTemplate::New(isolate, func, data, v8::Signature::New(isolate, recv))
         );
 }
-#line 126 "./src/util/macros.lzz"
+#line 130 "./src/util/macros.lzz"
 void SetPrototypeSymbolMethod (v8::Isolate * isolate, v8::Local <v8::External> data, v8::Local <v8::FunctionTemplate> recv, v8::Local <v8::Symbol> symbol, v8::FunctionCallback func)
-#line 132 "./src/util/macros.lzz"
+#line 136 "./src/util/macros.lzz"
   {
         v8::HandleScope scope(isolate);
         recv->PrototypeTemplate()->Set(

--- a/src/better_sqlite3.cpp
+++ b/src/better_sqlite3.cpp
@@ -13,7 +13,7 @@ void SetPrototypeGetter(
 	v8::HandleScope scope(isolate);
 
 	#if defined NODE_MODULE_VERSION && NODE_MODULE_VERSION < 121
-	recv->InstanceTemplate()->SetAccessor(
+	recv->InstanceTemplate()->SetNativeDataProperty(
 		InternalizedFromLatin1(isolate, name),
 		func,
 		0,
@@ -22,7 +22,7 @@ void SetPrototypeGetter(
 		v8::PropertyAttribute::None
 	);
 	#else
-	recv->InstanceTemplate()->SetAccessor(
+	recv->InstanceTemplate()->SetNativeDataProperty(
 		InternalizedFromLatin1(isolate, name),
 		func,
 		0,

--- a/src/better_sqlite3.cpp
+++ b/src/better_sqlite3.cpp
@@ -8,7 +8,7 @@ void SetPrototypeGetter(
 	v8::Local<v8::External> data,
 	v8::Local<v8::FunctionTemplate> recv,
 	const char* name,
-	v8::AccessorGetterCallback func
+	v8::AccessorNameGetterCallback func
 ) {
 	v8::HandleScope scope(isolate);
 
@@ -734,13 +734,13 @@ void Database::JS_unsafeMode (v8::FunctionCallbackInfo <v8 :: Value> const & inf
                 sqlite3_db_config(db->db_handle, SQLITE_DBCONFIG_DEFENSIVE, static_cast<int>(!db->unsafe_mode), NULL);
 }
 #line 415 "./src/objects/database.lzz"
-void Database::JS_open (v8::Local <v8 :: String> _, v8::PropertyCallbackInfo <v8 :: Value> const & info)
+void Database::JS_open (v8::Local <v8 :: Name> _, v8::PropertyCallbackInfo <v8 :: Value> const & info)
 #line 415 "./src/objects/database.lzz"
                              {
                 info.GetReturnValue().Set( node :: ObjectWrap :: Unwrap <Database>(info.This())->open);
 }
 #line 419 "./src/objects/database.lzz"
-void Database::JS_inTransaction (v8::Local <v8 :: String> _, v8::PropertyCallbackInfo <v8 :: Value> const & info)
+void Database::JS_inTransaction (v8::Local <v8 :: Name> _, v8::PropertyCallbackInfo <v8 :: Value> const & info)
 #line 419 "./src/objects/database.lzz"
                                       {
                 Database* db = node :: ObjectWrap :: Unwrap <Database>(info.This());
@@ -1109,7 +1109,7 @@ void Statement::JS_columns (v8::FunctionCallbackInfo <v8 :: Value> const & info)
                 info.GetReturnValue().Set(columns);
 }
 #line 321 "./src/objects/statement.lzz"
-void Statement::JS_busy (v8::Local <v8 :: String> _, v8::PropertyCallbackInfo <v8 :: Value> const & info)
+void Statement::JS_busy (v8::Local <v8 :: Name> _, v8::PropertyCallbackInfo <v8 :: Value> const & info)
 #line 321 "./src/objects/statement.lzz"
                              {
                 Statement* stmt = node :: ObjectWrap :: Unwrap <Statement>(info.This());

--- a/src/better_sqlite3.hpp
+++ b/src/better_sqlite3.hpp
@@ -22,7 +22,7 @@ void SetPrototypeGetter(
 	v8::Local<v8::External> data,
 	v8::Local<v8::FunctionTemplate> recv,
 	const char* name,
-	v8::AccessorGetterCallback func
+	v8::AccessorNameGetterCallback func
 );
 #line 36 "./src/util/binder.lzz"
 	static bool IsPlainObject(v8::Isolate* isolate, v8::Local<v8::Object> obj);
@@ -273,9 +273,9 @@ private:
 #line 408 "./src/objects/database.lzz"
   static void JS_unsafeMode (v8::FunctionCallbackInfo <v8 :: Value> const & info);
 #line 415 "./src/objects/database.lzz"
-  static void JS_open (v8::Local <v8 :: String> _, v8::PropertyCallbackInfo <v8 :: Value> const & info);
+  static void JS_open (v8::Local <v8 :: Name> _, v8::PropertyCallbackInfo <v8 :: Value> const & info);
 #line 419 "./src/objects/database.lzz"
-  static void JS_inTransaction (v8::Local <v8 :: String> _, v8::PropertyCallbackInfo <v8 :: Value> const & info);
+  static void JS_inTransaction (v8::Local <v8 :: Name> _, v8::PropertyCallbackInfo <v8 :: Value> const & info);
 #line 424 "./src/objects/database.lzz"
   static bool Deserialize (v8::Local <v8::Object> buffer, Addon * addon, sqlite3 * db_handle, bool readonly);
 #line 449 "./src/objects/database.lzz"
@@ -365,7 +365,7 @@ private:
 #line 278 "./src/objects/statement.lzz"
   static void JS_columns (v8::FunctionCallbackInfo <v8 :: Value> const & info);
 #line 321 "./src/objects/statement.lzz"
-  static void JS_busy (v8::Local <v8 :: String> _, v8::PropertyCallbackInfo <v8 :: Value> const & info);
+  static void JS_busy (v8::Local <v8 :: Name> _, v8::PropertyCallbackInfo <v8 :: Value> const & info);
 #line 326 "./src/objects/statement.lzz"
   Database * const db;
 #line 327 "./src/objects/statement.lzz"

--- a/src/better_sqlite3.hpp
+++ b/src/better_sqlite3.hpp
@@ -16,7 +16,7 @@
 #include <node.h>
 #include <node_object_wrap.h>
 #include <node_buffer.h>
-#line 141 "./src/util/macros.lzz"
+#line 145 "./src/util/macros.lzz"
 void SetPrototypeGetter(
 	v8::Isolate* isolate,
 	v8::Local<v8::External> data,
@@ -27,37 +27,37 @@ void SetPrototypeGetter(
 #line 36 "./src/util/binder.lzz"
 	static bool IsPlainObject(v8::Isolate* isolate, v8::Local<v8::Object> obj);
 #define LZZ_INLINE inline
-#line 16 "./src/util/macros.lzz"
+#line 20 "./src/util/macros.lzz"
 v8::Local <v8::String> StringFromUtf8 (v8::Isolate * isolate, char const * data, int length);
-#line 19 "./src/util/macros.lzz"
+#line 23 "./src/util/macros.lzz"
 v8::Local <v8::String> InternalizedFromUtf8 (v8::Isolate * isolate, char const * data, int length);
-#line 22 "./src/util/macros.lzz"
-v8::Local <v8::Value> InternalizedFromUtf8OrNull (v8::Isolate * isolate, char const * data, int length);
 #line 26 "./src/util/macros.lzz"
-v8::Local <v8::String> InternalizedFromLatin1 (v8::Isolate * isolate, char const * str);
+v8::Local <v8::Value> InternalizedFromUtf8OrNull (v8::Isolate * isolate, char const * data, int length);
 #line 30 "./src/util/macros.lzz"
-void SetFrozen (v8::Isolate * isolate, v8::Local <v8::Context> ctx, v8::Local <v8::Object> obj, v8::Global <v8::String> & key, v8::Local <v8::Value> value);
+v8::Local <v8::String> InternalizedFromLatin1 (v8::Isolate * isolate, char const * str);
 #line 34 "./src/util/macros.lzz"
+void SetFrozen (v8::Isolate * isolate, v8::Local <v8::Context> ctx, v8::Local <v8::Object> obj, v8::Global <v8::String> & key, v8::Local <v8::Value> value);
+#line 38 "./src/util/macros.lzz"
 void ThrowError (char const * message);
-#line 35 "./src/util/macros.lzz"
+#line 39 "./src/util/macros.lzz"
 void ThrowTypeError (char const * message);
-#line 36 "./src/util/macros.lzz"
+#line 40 "./src/util/macros.lzz"
 void ThrowRangeError (char const * message);
-#line 88 "./src/util/macros.lzz"
+#line 92 "./src/util/macros.lzz"
 bool IS_SKIPPED (char c);
-#line 93 "./src/util/macros.lzz"
+#line 97 "./src/util/macros.lzz"
 template <typename T>
-#line 93 "./src/util/macros.lzz"
+#line 97 "./src/util/macros.lzz"
 T * ALLOC_ARRAY (size_t count);
-#line 98 "./src/util/macros.lzz"
-template <typename T>
-#line 98 "./src/util/macros.lzz"
-void FREE_ARRAY (T * array_pointer);
 #line 102 "./src/util/macros.lzz"
+template <typename T>
+#line 102 "./src/util/macros.lzz"
+void FREE_ARRAY (T * array_pointer);
+#line 106 "./src/util/macros.lzz"
 v8::Local <v8::FunctionTemplate> NewConstructorTemplate (v8::Isolate * isolate, v8::Local <v8::External> data, v8::FunctionCallback func, char const * name);
-#line 113 "./src/util/macros.lzz"
+#line 117 "./src/util/macros.lzz"
 void SetPrototypeMethod (v8::Isolate * isolate, v8::Local <v8::External> data, v8::Local <v8::FunctionTemplate> recv, char const * name, v8::FunctionCallback func);
-#line 126 "./src/util/macros.lzz"
+#line 130 "./src/util/macros.lzz"
 void SetPrototypeSymbolMethod (v8::Isolate * isolate, v8::Local <v8::External> data, v8::Local <v8::FunctionTemplate> recv, v8::Local <v8::Symbol> symbol, v8::FunctionCallback func);
 #line 1 "./src/util/constants.lzz"
 class CS
@@ -807,56 +807,56 @@ struct Addon
 #line 63 "./src/better_sqlite3.lzz"
   std::set <Database*, Database::CompareDatabase> dbs;
 };
-#line 16 "./src/util/macros.lzz"
+#line 20 "./src/util/macros.lzz"
 LZZ_INLINE v8::Local <v8::String> StringFromUtf8 (v8::Isolate * isolate, char const * data, int length)
-#line 16 "./src/util/macros.lzz"
+#line 20 "./src/util/macros.lzz"
                                                                                                 {
         return v8::String::NewFromUtf8(isolate, data, v8::NewStringType::kNormal, length).ToLocalChecked();
 }
-#line 19 "./src/util/macros.lzz"
+#line 23 "./src/util/macros.lzz"
 LZZ_INLINE v8::Local <v8::String> InternalizedFromUtf8 (v8::Isolate * isolate, char const * data, int length)
-#line 19 "./src/util/macros.lzz"
+#line 23 "./src/util/macros.lzz"
                                                                                                       {
         return v8::String::NewFromUtf8(isolate, data, v8::NewStringType::kInternalized, length).ToLocalChecked();
 }
-#line 22 "./src/util/macros.lzz"
+#line 26 "./src/util/macros.lzz"
 LZZ_INLINE v8::Local <v8::Value> InternalizedFromUtf8OrNull (v8::Isolate * isolate, char const * data, int length)
-#line 22 "./src/util/macros.lzz"
+#line 26 "./src/util/macros.lzz"
                                                                                                            {
         if (data == NULL) return v8::Null(isolate);
         return InternalizedFromUtf8(isolate, data, length);
 }
-#line 26 "./src/util/macros.lzz"
+#line 30 "./src/util/macros.lzz"
 LZZ_INLINE v8::Local <v8::String> InternalizedFromLatin1 (v8::Isolate * isolate, char const * str)
-#line 26 "./src/util/macros.lzz"
+#line 30 "./src/util/macros.lzz"
                                                                                            {
         return v8::String::NewFromOneByte(isolate, reinterpret_cast<const uint8_t*>(str), v8::NewStringType::kInternalized).ToLocalChecked();
 }
-#line 30 "./src/util/macros.lzz"
+#line 34 "./src/util/macros.lzz"
 LZZ_INLINE void SetFrozen (v8::Isolate * isolate, v8::Local <v8::Context> ctx, v8::Local <v8::Object> obj, v8::Global <v8::String> & key, v8::Local <v8::Value> value)
-#line 30 "./src/util/macros.lzz"
+#line 34 "./src/util/macros.lzz"
                                                                                                                                                             {
         obj->DefineOwnProperty(ctx, key.Get(isolate), value, static_cast<v8::PropertyAttribute>(v8::DontDelete | v8::ReadOnly)).FromJust();
 }
-#line 88 "./src/util/macros.lzz"
+#line 92 "./src/util/macros.lzz"
 LZZ_INLINE bool IS_SKIPPED (char c)
-#line 88 "./src/util/macros.lzz"
+#line 92 "./src/util/macros.lzz"
                                {
         return c == ' ' || c == ';' || (c >= '\t' && c <= '\r');
 }
-#line 93 "./src/util/macros.lzz"
+#line 97 "./src/util/macros.lzz"
 template <typename T>
-#line 93 "./src/util/macros.lzz"
+#line 97 "./src/util/macros.lzz"
 LZZ_INLINE T * ALLOC_ARRAY (size_t count)
-#line 93 "./src/util/macros.lzz"
+#line 97 "./src/util/macros.lzz"
                                                       {
         return static_cast<T*>(::operator new[](count * sizeof(T)));
 }
-#line 98 "./src/util/macros.lzz"
+#line 102 "./src/util/macros.lzz"
 template <typename T>
-#line 98 "./src/util/macros.lzz"
+#line 102 "./src/util/macros.lzz"
 LZZ_INLINE void FREE_ARRAY (T * array_pointer)
-#line 98 "./src/util/macros.lzz"
+#line 102 "./src/util/macros.lzz"
                                                            {
         ::operator delete[](array_pointer);
 }

--- a/src/util/macros.lzz
+++ b/src/util/macros.lzz
@@ -157,7 +157,7 @@ void SetPrototypeGetter(
 	v8::HandleScope scope(isolate);
 
 	#if defined NODE_MODULE_VERSION && NODE_MODULE_VERSION < 121
-	recv->InstanceTemplate()->SetAccessor(
+	recv->InstanceTemplate()->SetNativeDataProperty(
 		InternalizedFromLatin1(isolate, name),
 		func,
 		0,
@@ -166,7 +166,7 @@ void SetPrototypeGetter(
 		v8::PropertyAttribute::None
 	);
 	#else
-	recv->InstanceTemplate()->SetAccessor(
+	recv->InstanceTemplate()->SetNativeDataProperty(
 		InternalizedFromLatin1(isolate, name),
 		func,
 		0,

--- a/src/util/macros.lzz
+++ b/src/util/macros.lzz
@@ -1,7 +1,7 @@
 #define NODE_ARGUMENTS const v8::FunctionCallbackInfo<v8::Value>&
 #define NODE_ARGUMENTS_POINTER const v8::FunctionCallbackInfo<v8::Value>*
 #define NODE_METHOD(name) static void name(NODE_ARGUMENTS info)
-#define NODE_GETTER(name) static void name(v8::Local<v8::String> _, const v8::PropertyCallbackInfo<v8::Value>& info)
+#define NODE_GETTER(name) static void name(v8::Local<v8::Name> _, const v8::PropertyCallbackInfo<v8::Value>& info)
 #define INIT(name) static v8::Local<v8::Function> name(v8::Isolate* isolate, v8::Local<v8::External> data)
 
 #define EasyIsolate v8::Isolate* isolate = v8::Isolate::GetCurrent()
@@ -143,7 +143,7 @@ void SetPrototypeGetter(
 	v8::Local<v8::External> data,
 	v8::Local<v8::FunctionTemplate> recv,
 	const char* name,
-	v8::AccessorGetterCallback func
+	v8::AccessorNameGetterCallback func
 );
 #end
 #src
@@ -152,7 +152,7 @@ void SetPrototypeGetter(
 	v8::Local<v8::External> data,
 	v8::Local<v8::FunctionTemplate> recv,
 	const char* name,
-	v8::AccessorGetterCallback func
+	v8::AccessorNameGetterCallback func
 ) {
 	v8::HandleScope scope(isolate);
 

--- a/src/util/macros.lzz
+++ b/src/util/macros.lzz
@@ -1,7 +1,11 @@
 #define NODE_ARGUMENTS const v8::FunctionCallbackInfo<v8::Value>&
 #define NODE_ARGUMENTS_POINTER const v8::FunctionCallbackInfo<v8::Value>*
 #define NODE_METHOD(name) static void name(NODE_ARGUMENTS info)
+#if defined NODE_MODULE_VERSION && NODE_MODULE_VERSION < 121
+#define NODE_GETTER(name) static void name(v8::Local<v8::String> _, const v8::PropertyCallbackInfo<v8::Value>& info)
+#else
 #define NODE_GETTER(name) static void name(v8::Local<v8::Name> _, const v8::PropertyCallbackInfo<v8::Value>& info)
+#endif
 #define INIT(name) static v8::Local<v8::Function> name(v8::Isolate* isolate, v8::Local<v8::External> data)
 
 #define EasyIsolate v8::Isolate* isolate = v8::Isolate::GetCurrent()
@@ -157,7 +161,7 @@ void SetPrototypeGetter(
 	v8::HandleScope scope(isolate);
 
 	#if defined NODE_MODULE_VERSION && NODE_MODULE_VERSION < 121
-	recv->InstanceTemplate()->SetNativeDataProperty(
+	recv->InstanceTemplate()->SetAccessor(
 		InternalizedFromLatin1(isolate, name),
 		func,
 		0,


### PR DESCRIPTION
With the release of Electron v32 some classes and functions marked as deprecated have been removed and require adjustments. Also c++20 is now required by v8.