### PR TITLE
Update thread count calculation method in worker_threads example

### DIFF
--- a/docs/threads.md
+++ b/docs/threads.md
@@ -55,7 +55,7 @@ function drainQueue() {
   Spawn workers that try to drain the queue.
  */
 
-os.cpus().forEach(function spawn() {
+new Array(os.availableParallelism()).fill(null).forEach(function spawn() {
   const worker = new Worker('./worker.js');
 
   let job = null; // Current item from the queue


### PR DESCRIPTION
The Node.js documentation states that `os.cpus()` should not be used to calculate the amount of threads an app should launch because CPU information might be unavailable ([source](https://nodejs.org/api/os.html#oscpus)).

In Node.js v19.4.0 and v18.14.0, `os.availableParallelism()` was added for that purpose.