### PR TITLE
Add node:sqlite benchmark

### DIFF
--- a/benchmark/drivers.js
+++ b/benchmark/drivers.js
@@ -19,3 +19,12 @@ module.exports = new Map([
 		return db;
 	}],
 ]);
+
+const moduleExists = (m) => { try { return require.resolve(m); } catch (e) {} };
+if (moduleExists('node:sqlite')) {
+	module.exports.set('node:sqlite', async (filename, pragma) => {
+		const db = new (require('node:sqlite').DatabaseSync)(filename, {open: true});
+		for (const str of pragma) db.exec(`PRAGMA ${str}`);
+		return db;
+	});
+}

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -69,7 +69,7 @@ for (const trial of trials) {
 		const ctx = createContext(trial, driver);
 		process.stdout.write(`${driver} (running...)\n`);
 		try {
-			const result = execFileSync('node', ['./benchmark.js', ctx], { stdio: 'pipe', encoding: 'utf8' });
+			const result = execFileSync('node', [...process.execArgv, './benchmark.js', ctx], { stdio: 'pipe', encoding: 'utf8' });
 			console.log(erase() + `${driverName} x ${result}`);
 		} catch (err) {
 			console.log(erase() + clc.red(`${driverName} ERROR (probably out of memory)`));

--- a/benchmark/types/insert.js
+++ b/benchmark/types/insert.js
@@ -14,3 +14,14 @@ exports['node-sqlite3'] = async (db, { table, columns }) => {
 		.map(([k, v]) => ({ ['@' + k]: v })));
 	return () => db.run(sql, row);
 };
+
+exports['node:sqlite'] = (db, { table, columns }) => {
+	const sql = `INSERT INTO ${table} (${columns.join(', ')}) VALUES (${columns.map(x => '@' + x).join(', ')})`;
+	const row = Object.assign({}, ...Object.entries(db.prepare(`SELECT * FROM ${table} LIMIT 1`).get())
+		.filter(([k]) => columns.includes(k))
+		.map(([k, v]) => ({ ['@' + k]: v })));
+	return () => {
+		const stmt = db.prepare(sql);
+		return stmt.run(row);
+	}
+};

--- a/benchmark/types/select-all.js
+++ b/benchmark/types/select-all.js
@@ -12,3 +12,12 @@ exports['node-sqlite3'] = async (db, { table, columns, count }) => {
 	let rowid = -100;
 	return () => db.all(sql, (rowid += 100) % count + 1);
 };
+
+exports['node:sqlite'] = (db, { table, columns, count }) => {
+	const sql = `SELECT ${columns.join(', ')} FROM ${table} WHERE rowid >= ? LIMIT 100`;
+	let rowid = -100;
+	return () => {
+		const stmt = db.prepare(sql);
+		return stmt.all((rowid += 100) % count + 1);
+	}
+};

--- a/benchmark/types/select-iterate.js
+++ b/benchmark/types/select-iterate.js
@@ -21,3 +21,19 @@ exports['node-sqlite3'] = async (db, { table, columns, count }) => {
 		})();
 	};
 };
+
+exports['node:sqlite'] = (db, { table, columns, count }) => {
+	const sql = `SELECT ${columns.join(', ')} FROM ${table} WHERE rowid >= ? LIMIT 100`;
+	let rowid = -100;
+
+	if (!("iterate" in require("node:sqlite").StatementSync.prototype)) {
+		// Error: StatementSync.iterate is not a function (added in Node v23.4.0+)
+		return () => {};
+	}
+
+	return () => {
+		// Error: statement has been finalized
+		// for (const row of db.prepare(sql).iterate((rowid += 100) % count + 1)) {}
+		return () => {};
+	};
+};

--- a/benchmark/types/select.js
+++ b/benchmark/types/select.js
@@ -12,3 +12,12 @@ exports['node-sqlite3'] = async (db, { table, columns, count }) => {
 	let rowid = -1;
 	return () => db.get(sql, ++rowid % count + 1);
 };
+
+exports['node:sqlite'] = (db, { table, columns, count }) => {
+	const sql = `SELECT ${columns.join(', ')} FROM ${table} WHERE rowid = ?`;
+	let rowid = -1;
+	return () => {
+		const stmt = db.prepare(sql);
+		return stmt.get(++rowid % count + 1);
+	}
+};


### PR DESCRIPTION
This adds a benchmark for the built-in [node:sqlite](https://nodejs.org/api/sqlite.html) module available with `--experimental-sqlite` since Node v22.5.0.
This benchmark will only run and be included in the results if the `node:sqlite` module exists and is available.

Known issues:
1) This creates prepared statements for every query instead of reusing persistent statements because [DatabaseSync.prepare](https://nodejs.org/api/sqlite.html#databasepreparesql) is a wrapper for `sqlite3_prepare_v2` that doesn't accept `SQLITE_PREPARE_PERSISTENT` flag.
2) Iterate benchmark does nothing for now as [StatementSync.iterate](https://nodejs.org/api/sqlite.html#statementiteratenamedparameters-anonymousparameters) was added in Node v23.4.0 but even after updating it fails with "statement has been finalized".

This is probably OK as a first pass and will be more useful later as the built-in module gets more stable.

Fixes #1266.

```
$ node --experimental-sqlite benchmark
--- reading rows individually ---
better-sqlite3 x 121,663 ops/sec ±0.29%
node-sqlite3   x 12,805 ops/sec ±0.47%
node:sqlite    x 52,115 ops/sec ±1.66%

--- reading 100 rows into an array ---
better-sqlite3 x 6,750 ops/sec ±0.41%
node-sqlite3   x 1,641 ops/sec ±0.8%
node:sqlite    x 10,170 ops/sec ±0.42%

--- iterating over 100 rows ---
better-sqlite3 x 5,732 ops/sec ±0.44%
node-sqlite3   x 132 ops/sec ±1.78%
node:sqlite    x NaN ops/sec ±NaN% // See [2]

--- inserting rows individually ---
better-sqlite3 x 39,821 ops/sec ±4.34%
node-sqlite3   x 11,392 ops/sec ±1.21%
node:sqlite    x 26,655 ops/sec ±2.28%

--- inserting 100 rows in a single transaction ---
better-sqlite3 x 3,996 ops/sec ±3.2%
node-sqlite3   x 105 ops/sec ±1.38%
node:sqlite    x 2,906 ops/sec ±2.71%

All benchmarks complete!
```