### PR TITLE
Update the Ubuntu runner image in build script to `ubuntu-22.04`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
           - macos-13
           - macos-14
           - windows-2019
@@ -67,7 +67,7 @@ jobs:
   publish:
     if: ${{ github.event_name == 'release' }}
     name: Publishing to NPM
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
       - prebuild
       - prebuild-alpine
@@ -89,7 +89,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
           - macos-13
           - macos-14
           - windows-2019


### PR DESCRIPTION
This is a necessary update since the `ubuntu-20.04` runner will be [fully unsupported by the 1st of April](https://github.com/actions/runner-images/issues/11101).

Builds might run into issues and the build artifacts might not be fully compatible with some older distros _(`glibc` fiasco)_. Guess we're gonna have to test and debug.