### PR TITLE
docs: fix clone url at benchmark.md

### DIFF
--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -3,7 +3,7 @@
 To run the benchmark yourself:
 
 ```bash
-git clone https://github.com/JoshuaWise/better-sqlite3.git
+git clone https://github.com/WiseLibs/better-sqlite3.git
 cd better-sqlite3
 npm install # if you're doing this as the root user, --unsafe-perm is required
 node benchmark


### PR DESCRIPTION
This PR updates the repository URL at `benchmark.md` to the current project's path.

* [`docs/benchmark.md`](diffhunk://#diff-3d312199f1da21c13b99d654a88a249129c2d8d05712a224085c98f16ff19315L6-R6): Updated the repository URL from `https://github.com/JoshuaWise/better-sqlite3.git` to `https://github.com/WiseLibs/better-sqlite3.git`.