### PR TITLE
Disallow transaction to return a Promise due to unexpected behaviour

### DIFF
--- a/lib/methods/transaction.js
+++ b/lib/methods/transaction.js
@@ -63,6 +63,9 @@ const wrapTransaction = (apply, fn, db, { begin, commit, rollback, savepoint, re
 	before.run();
 	try {
 		const result = apply.call(fn, this, arguments);
+		if (result && typeof result.then === 'function') {
+			throw new TypeError('Transaction function cannot return a promise');
+		}
 		after.run();
 		return result;
 	} catch (ex) {


### PR DESCRIPTION
As described in https://github.com/WiseLibs/better-sqlite3/issues/319:


> You should never keep SQLite3 transactions open across event loop ticks in Node.js. SQLite3 serializes all statements/transactions. This means, if you try to run an asynchronous function within an SQL statement, you'll block all other statements/transactions across your entire program. better-sqlite3 doesn't support it, and it never will, because it's a very bad idea.

This is reasonable. **But**: Currently if a user passes an async function as a transaction callback, the resulting behaviour is very confusing and **dangerous**: It will run the first statement within the transaction, commit the transaction, and then the other part of the async function will run at a random time later without any transaction context, errors not being rolled back.

Instead, the least we can do is detect this case (that a lot of users have already hit if you look at the multiple issues opened about this) and reject it.