### PR TITLE
Use correct flag to determine if V8 Sandboxing is enabled

### DIFF
--- a/src/util/macros.lzz
+++ b/src/util/macros.lzz
@@ -179,16 +179,18 @@ void SetPrototypeGetter(
 	#endif
 }
 #end
-
 #src
-#ifndef V8_COMPRESS_POINTERS_IN_SHARED_CAGE
-#define SAFE_NEW_BUFFER(env, data, length, finalizeCallback, finalizeHint) node::Buffer::New(env, data, length, finalizeCallback, finalizeHint)
-#else
+#if defined(V8_ENABLE_SANDBOX)
+// When V8 Sandbox is enabled (in newer Electron versions), we need to use Buffer::Copy
+// instead of Buffer::New to ensure the ArrayBuffer backing store is allocated inside the sandbox
 static inline v8::MaybeLocal<v8::Object> BufferSandboxNew(v8::Isolate* isolate, char* data, size_t length, void (*finalizeCallback)(char*, void*), void* finalizeHint) {
-	v8::MaybeLocal<v8::Object> buffer = node::Buffer::Copy(isolate, data, length);
-	finalizeCallback(data, finalizeHint);
-	return buffer;
+    v8::MaybeLocal<v8::Object> buffer = node::Buffer::Copy(isolate, data, length);
+    finalizeCallback(data, finalizeHint);
+    return buffer;
 }
 #define SAFE_NEW_BUFFER(env, data, length, finalizeCallback, finalizeHint) BufferSandboxNew(env, data, length, finalizeCallback, finalizeHint)
+#else
+// When V8 Sandbox is not enabled, we can use the more efficient Buffer::New
+#define SAFE_NEW_BUFFER(env, data, length, finalizeCallback, finalizeHint) node::Buffer::New(env, data, length, finalizeCallback, finalizeHint)
 #endif
 #end


### PR DESCRIPTION
Electron switched to using v8's sandboxing feature as of V21. With this enabled, allocating a buffer using `node::Buffer::New` crashes the program, because it attempts to allocate memory outside of the allowed memory address range of the sandbox.  

```
[23992:0508/184214.301:ERROR:node_bindings.cc(162)] Fatal error in V8: v8_ArrayBuffer_NewBackingStore When the V8 Sandbox is enabled, ArrayBuffer backing stores must be allocated inside the sandbox address space. Please use an appropriate ArrayBuffer::Allocator to allocate these buffers, or disable the sandbox.
 ```

Reproducing the issue is as simple as calling `db.serialize()` in Electron versions 30.0 and higher.

 PR #1036 fixed this for electron versions until 30.x.x+, where this fix broke. Why this only broke in the most recent Electron versions, I'm not sure, but there were 2 issues:
- The flag being checked is rarely used, and also was not the proper one to use for determining if V8 sandboxing is enabled. That would be `V8_ENABLE_SANDBOX` .  This is also the flag that Electron uses: https://github.com/electron/electron/blob/main/patches/node/support_v8_sandboxed_pointers.patch
- The conditions were illogical: "if sandboxing is enabled, use the allocation method that should violate sandboxing rules and crash the program". This never should never have worked, and yet it did until v30.   

I tested the minimum repro with these changes inside of an Electron app, and it behaves as expected now. (#1372 )