### PR TITLE
docs: update troubleshooting instructions for node-gyp errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ npm install better-sqlite3
 
 > Requires Node.js v14.21.1 or later. Prebuilt binaries are available for [LTS versions](https://nodejs.org/en/about/releases/). If you have trouble installing, check the [troubleshooting guide](./docs/troubleshooting.md).
 
+### If you don't want to setup `node-gyp` ...
+
+```
+npm install better-sqlite3 --ignore-scripts
+```
+
+Then go to the [Releases](https://github.com/WiseLibs/better-sqlite3/releases/) page to download the corresponding version and place the file at `node_modules/better-sqlite3/build/Release/better_sqlite3.node`
+
 ## Usage
 
 ```js

--- a/README.md
+++ b/README.md
@@ -34,14 +34,6 @@ npm install better-sqlite3
 
 > Requires Node.js v14.21.1 or later. Prebuilt binaries are available for [LTS versions](https://nodejs.org/en/about/releases/). If you have trouble installing, check the [troubleshooting guide](./docs/troubleshooting.md).
 
-### If you don't want to setup `node-gyp` ...
-
-```
-npm install better-sqlite3 --ignore-scripts
-```
-
-Then go to the [Releases](https://github.com/WiseLibs/better-sqlite3/releases/) page to download the corresponding version and place the file at `node_modules/better-sqlite3/build/Release/better_sqlite3.node`
-
 ## Usage
 
 ```js

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -10,6 +10,19 @@ If `better-sqlite3` refuses to install, follow these guidelines:
 
 - Make sure you're using a [supported version of Node.js](https://nodejs.org/en/about/previous-releases). `better-sqlite3` is only tested with currently-supported versions of Node.js.
 
+## Encountering a `node-gyp` error report
+
+This error may occur when the pre-built file cannot be obtained properly.
+To bypass the post-installation script, run the following command first:
+
+```
+npm install better-sqlite3 --ignore-scripts
+```
+
+Then, navigate to the [Releases](https://github.com/WiseLibs/better-sqlite3/releases/) page to download the corresponding version.
+After downloading, place the file in the following location:
+`node_modules/better-sqlite3/build/Release/better_sqlite3.node`
+
 ## "Install the necessary tools" 
    
 - If you're on Windows, during installation of Node.js, be sure to select "Automatically install the necessary tools" from the "Tools for Native Modules" page.


### PR DESCRIPTION
Remind users that they don't have to install `node-gyp` and can directly use the releases files.

![349b86f24f5d5d63de7517ddfdd9414e](https://github.com/user-attachments/assets/3ffb125a-e4c0-4ece-b1e3-71c01f11c1f8)
![image](https://github.com/user-attachments/assets/da88a9ee-7038-4321-8943-4036a3d6ebe7)
