### PR TITLE
Use node-abi 4.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,11 @@
     "bindings": "^1.5.0",
     "prebuild-install": "^7.1.1"
   },
+  "overrides": {
+    "prebuild": {
+      "node-abi": "4.9.0"
+    }
+  },
   "devDependencies": {
     "chai": "^4.3.8",
     "cli-color": "^2.0.3",


### PR DESCRIPTION
Adds an override to the node-abi version used by prebuild to cover latest ABI versions. This should also fix the prebuilt binary for NodeJS 24 having ABI version 134 (pre release) instead of 137.