### PR TITLE
Update the Windows runner on build workflow to `windows-2022`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
           - ubuntu-22.04
           - macos-13
           - macos-14
-          - windows-2019
+          - windows-2022
         node:
           - 20
           - 22
@@ -91,7 +91,7 @@ jobs:
         os:
           - macos-13
           - macos-14
-          - windows-2019
+          - windows-2022
     name: Prebuild on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     needs: test
@@ -107,7 +107,7 @@ jobs:
       - run: npm install --ignore-scripts
       - run: ${{ env.NODE_BUILD_CMD }} -u ${{ secrets.GITHUB_TOKEN }}
       - run: ${{ env.ELECTRON_BUILD_CMD }} -u ${{ secrets.GITHUB_TOKEN }}
-      - if: matrix.os == 'windows-2019'
+      - if: matrix.os == 'windows-2022'
         run: |
           ${{ env.NODE_BUILD_CMD }} --arch ia32 -u ${{ secrets.GITHUB_TOKEN }}
           ${{ env.NODE_BUILD_CMD }} --arch arm64 -u ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The support for `windows-2019` runner has [officially been dropped](https://github.com/actions/runner-images/issues/12045). IIRC, we only kept the `windows-2019` runner to continue building for Node `v16`, which has also been EOL for some time now.

This PR updates the Windows runner on all workflow jobs to `windows-2022`. Successful tests can be seen [here](https://github.com/m4heshd/better-sqlite3-multiple-ciphers/actions/runs/16024127041) and [here](https://github.com/m4heshd/better-sqlite3-multiple-ciphers/actions/runs/16024279545).