### PR TITLE
Include all source files in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "main": "lib/index.js",
   "files": [
     "binding.gyp",
-    "src/*.[ch]pp",
+    "src/**/*.[ch]pp",
     "lib/**",
     "deps/**"
   ],


### PR DESCRIPTION
With the deprecation and removal of lzz, the glob pattern for the files to include in the package is too narrow. Adjusted the pattern to include all files below src.