### PR TITLE
Add missing macOS x64 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,8 +27,8 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-          - macos-14
           - macos-15
+          - macos-15-large
           - windows-2022
         node:
           - 20
@@ -89,8 +89,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-14
           - macos-15
+          - macos-15-large
           - windows-2022
     name: Prebuild on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This PR reinstates the macOS x64 runner in the build script.

Since the last update to the build script, both of the macOS runners (`macos-14` and `macos-15`) now being used are arm64 runners, which results in duplicate artifacts. Also, the artifacts are now missing macOS x64 builds.