### PR TITLE
Fix npm publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,9 @@ jobs:
     if: ${{ github.event_name == 'release' }}
     name: Publishing to NPM
     runs-on: ubuntu-22.04
+    permissions:
+      id-token: write # Required for OIDC trusted publishing
+      contents: read
     needs:
       - prebuild
       - prebuild-alpine
@@ -95,9 +98,9 @@ jobs:
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org
-      - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Upgrade npm for OIDC support
+        run: npm install -g npm@latest
+      - run: npm publish --provenance
 
   prebuild:
     if: ${{ github.event_name == 'release' }}


### PR DESCRIPTION
Publishing the last version to `npm` failed because `npm` is finally enforcing reasonable security constraints: https://github.blog/changelog/2025-09-29-strengthening-npm-security-important-changes-to-authentication-and-token-management/

See https://github.com/photostructure/mkver for a working GitHub Action that uses [`npm publish --provenance`](https://github.com/photostructure/mkver/blob/35fb747bba1b3bacde9d902222e70ae74a91f8f0/.github/workflows/build.yml#L92)

See https://docs.npmjs.com/trusted-publishers for more details.

@JoshuaWise you'll need to update the OIDC settings section on https://www.npmjs.com/package/better-sqlite3/access before this works.

You can also remove the NPM_TOKEN from this project's secrets.