### PR TITLE
fix build: update node-abi version in package.json to ^4.25.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "overrides": {
     "prebuild": {
-      "node-abi": "4.15.0"
+      "node-abi": "^4.25.0"
     }
   },
   "devDependencies": {


### PR DESCRIPTION
Fix for broken build: https://github.com/WiseLibs/better-sqlite3/actions/runs/21073559393/job/60610149109

(our current version of node-abi doesn't know about Electron v40)