### PR TITLE
Readme: requires Node.js v20 or later

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The fastest and simplest library for SQLite in Node.js.
 npm install better-sqlite3
 ```
 
-> Requires Node.js v20 or later. Prebuilt binaries are available for [LTS versions](https://nodejs.org/en/about/releases/). If you have trouble installing, check the [troubleshooting guide](./docs/troubleshooting.md).
+> Requires a currently supported Node.js version (see https://nodejs.org/en/about/previous-releases or https://endoflife.date/nodejs). Prebuilt binaries are available for [LTS versions](https://nodejs.org/en/about/releases/). If you have trouble installing, check the [troubleshooting guide](./docs/troubleshooting.md).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The fastest and simplest library for SQLite in Node.js.
 npm install better-sqlite3
 ```
 
-> Requires Node.js v14.21.1 or later. Prebuilt binaries are available for [LTS versions](https://nodejs.org/en/about/releases/). If you have trouble installing, check the [troubleshooting guide](./docs/troubleshooting.md).
+> Requires Node.js v20 or later. Prebuilt binaries are available for [LTS versions](https://nodejs.org/en/about/releases/). If you have trouble installing, check the [troubleshooting guide](./docs/troubleshooting.md).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The fastest and simplest library for SQLite in Node.js.
 npm install better-sqlite3
 ```
 
-> Requires a currently supported Node.js version (see https://nodejs.org/en/about/previous-releases or https://endoflife.date/nodejs). Prebuilt binaries are available for [LTS versions](https://nodejs.org/en/about/releases/). If you have trouble installing, check the [troubleshooting guide](./docs/troubleshooting.md).
+> Requires a [currently supported Node.js](https://nodejs.org/en/about/previous-releases) version. Prebuilt binaries are available for [LTS versions](https://nodejs.org/en/about/previous-releases). If you have trouble installing, check the [troubleshooting guide](./docs/troubleshooting.md).
 
 ## Usage
 


### PR DESCRIPTION
Kind of references https://github.com/WiseLibs/better-sqlite3/issues/1442

Maybe we should change the wording to be more generic and not require an update in the future. Or it should be (automatically) aligned with `packagejson.engines.node`?