### PR TITLE
Replace prebuild-install with node-gyp

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "bindings": "^1.5.0",
-    "prebuild-install": "^7.1.1"
+    "node-gyp": "^12.2.0"
   },
   "overrides": {
     "prebuild": {


### PR DESCRIPTION
Hello !
Thank you for all your work :grin: !

`prebuild-install` has been deprecated and now recommand to use `node-gyp` instead

I've tried locally and nothing seem to be broken as `node-gyp` it's already the fallback building method

Have a nice day :grin: !