### PR TITLE
Disable fail-fast on test jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,7 @@ env:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         os:
           - ubuntu-22.04


### PR DESCRIPTION
Allows all tests to run so we can see what's actually failing at the moment.