### PR TITLE
Fix Node v25 test errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,7 @@ env:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         os:
           - ubuntu-22.04


### PR DESCRIPTION
Testing against Node v25 is currently problematic due to https://github.com/nodejs/node/issues/61971. This locks the test runtime version to the last known working version. This also disables fail-fast for tests. 