### PR TITLE
fix: use Holder() instead of This() for Electron 41 compatibility

### DIFF
--- a/src/objects/database.cpp
+++ b/src/objects/database.cpp
@@ -408,10 +408,10 @@ NODE_METHOD(Database::JS_unsafeMode) {
 }
 
 NODE_GETTER(Database::JS_open) {
-	info.GetReturnValue().Set(Unwrap<Database>(info.This())->open);
+	info.GetReturnValue().Set(Unwrap<Database>(info.Holder())->open);
 }
 
 NODE_GETTER(Database::JS_inTransaction) {
-	Database* db = Unwrap<Database>(info.This());
+	Database* db = Unwrap<Database>(info.Holder());
 	info.GetReturnValue().Set(db->open && !static_cast<bool>(sqlite3_get_autocommit(db->db_handle)));
 }

--- a/src/objects/statement.cpp
+++ b/src/objects/statement.cpp
@@ -378,6 +378,6 @@ NODE_METHOD(Statement::JS_columns) {
 }
 
 NODE_GETTER(Statement::JS_busy) {
-	Statement* stmt = Unwrap<Statement>(info.This());
+	Statement* stmt = Unwrap<Statement>(info.Holder());
 	info.GetReturnValue().Set(stmt->alive && stmt->locked);
 }


### PR DESCRIPTION
  - Electron 41 (V8 13.x) removed `PropertyCallbackInfo::This()`, causing 3 compilation errors in `NODE_GETTER` functions        
  - Replaced with `Holder()`, which is the correct and only method on `PropertyCallbackInfo` for accessing the holder object     
                                                                                                                                 
  Affected functions:                                                                                                            
  - `Database::JS_open`                                                                                                          
  - `Database::JS_inTransaction`                                                                                                 
  - `Statement::JS_busy`                                                                                                         
                                                                                                                                 
  Note: `FunctionCallbackInfo::This()` (used in `NODE_METHOD` contexts) is unaffected — V8 removed `Holder()` from               
  `FunctionCallbackInfo` and `This()` from `PropertyCallbackInfo`, moving each class to a single correct method.                 
                                                                                                                                 
  ## References                                                                                                                  
                                                                                                                                 
  - [V8 `PropertyCallbackInfo` API](https://v8.github.io/api/head/classv8_1_1PropertyCallbackInfo.html) has `Holder()`, no  `This()`                                                                                                                       
  - [V8 `FunctionCallbackInfo` API](https://v8.github.io/api/head/classv8_1_1FunctionCallbackInfo.html) has `This()`, no `Holder()`                                                                                                                     
  - [crbug.com/333672197](https://issues.chromium.org/issues/333672197) — V8 tracking bug for these API changes                  
  - [Node.js PR #53474](https://github.com/nodejs/node/pull/53474) — related migration for `FunctionCallbackInfo`                
