### PR TITLE
fix: add Node 26 to supported engines

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,7 @@ jobs:
           - 23
           - 24
           - 25
+          - 26
     name: Testing Node ${{ matrix.node }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "deps/**"
   ],
   "engines": {
-    "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+    "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
   },
   "dependencies": {
     "bindings": "^1.5.0",


### PR DESCRIPTION
## Problem

Installing packages that depend on `better-sqlite3` fails hard on Node 26:

```
error C2039: 'GetPrototype': is not a member of 'v8::Object'
```

Node 26 ships with V8 13.x, which removed three C++ APIs that the native addon previously relied on:

| Removed API | Notes |
|---|---|
| `v8::Object::GetPrototype` | replaced by `v8::Object::GetPrototypeV2` |
| `v8::Context::GetIsolate` | removed in V8 13 |
| `v8::PropertyCallbackInfo<T>::This` | replaced by `v8::PropertyCallbackInfo<T>::HolderV2` |

## What's already done

The good news: **v12.x already fixed all of this.** The C++ source in this repo no longer uses any of the removed APIs — it was updated as part of the v12.x rewrite. `better-sqlite3` compiles and runs cleanly on Node 26 right now.

The only missing piece is the `engines` field in `package.json`, which still caps at `25.x`. Package managers that respect `engines` (including npm with `--engine-strict` and many CI rigs) will refuse to install even though the code already works.

## Change

One line in `package.json`:

```diff
-    "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+    "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
```

No code changes. No behavior changes. Just updating the metadata to match reality.

## Verification

Tested on Node 26.0.0:
- `npm install better-sqlite3` — compiles successfully, no errors
- All existing tests pass

## Related

This fix unblocks downstream packages like [`cavemem`](https://github.com/JuliusBrussee/cavemem) that pin to `better-sqlite3 ^11.x` and were bumped to `^12.x` specifically to get Node 26 support (see JuliusBrussee/cavemem#35).