### PR TITLE
Fix V8 external API usage for Electron 42

### DIFF
--- a/src/better_sqlite3.cpp
+++ b/src/better_sqlite3.cpp
@@ -57,7 +57,7 @@ NODE_MODULE_INIT(/* exports, context */) {
 
 	// Initialize addon instance.
 	Addon* addon = new Addon(isolate);
-	v8::Local<v8::External> data = v8::External::New(isolate, addon);
+	v8::Local<v8::External> data = EXTERNAL_NEW(isolate, addon);
 	node::AddEnvironmentCleanupHook(isolate, Addon::Cleanup, addon);
 
 	// Create and export native-backed classes and functions.

--- a/src/util/helpers.cpp
+++ b/src/util/helpers.cpp
@@ -89,7 +89,7 @@ void SetPrototypeGetter(
 	recv->InstanceTemplate()->SetNativeDataProperty(
 		InternalizedFromLatin1(isolate, name),
 		func,
-		0,
+		nullptr,
 		data
 	);
 }

--- a/src/util/macros.cpp
+++ b/src/util/macros.cpp
@@ -27,7 +27,14 @@
 #define EasyIsolate v8::Isolate* isolate = v8::Isolate::GetCurrent()
 #define OnlyIsolate info.GetIsolate()
 #define OnlyContext isolate->GetCurrentContext()
-#define OnlyAddon static_cast<Addon*>(info.Data().As<v8::External>()->Value())
+#if defined(NODE_MODULE_VERSION) && NODE_MODULE_VERSION >= 146
+#define EXTERNAL_NEW(isolate, value) v8::External::New((isolate), (value), 0)
+#define EXTERNAL_VALUE(value) (value)->Value(0)
+#else
+#define EXTERNAL_NEW(isolate, value) v8::External::New((isolate), (value))
+#define EXTERNAL_VALUE(value) (value)->Value()
+#endif
+#define OnlyAddon static_cast<Addon*>(EXTERNAL_VALUE(info.Data().As<v8::External>()))
 #define UseIsolate v8::Isolate* isolate = OnlyIsolate
 #define UseContext v8::Local<v8::Context> ctx = OnlyContext
 #define UseAddon Addon* addon = OnlyAddon


### PR DESCRIPTION
## Summary
- add compatibility macros for tagged v8::External creation/access on V8 14+
- pass nullptr for missing SetNativeDataProperty setter to avoid Electron 42 overload ambiguity
- follow the existing V8 version-guard pattern used by prior Electron compatibility work such as #1459

## Verification
- npm run build-debug
- npm test
- minimal Electron 42.1.0 rebuild from source with @electron/rebuild:
  npx electron-rebuild -v 42.1.0 --types dev,prod,optional --force --build-from-source

Fixes #1474