### PR TITLE
fix: prevent SIGSEGV on worker exit when wrappers survive into final GC

### DIFF
--- a/src/addon.cpp
+++ b/src/addon.cpp
@@ -8,6 +8,16 @@ struct Addon {
 		Addon* addon = static_cast<Addon*>(ptr);
 		for (Database* db : addon->dbs) db->CloseHandles();
 		addon->dbs.clear();
+		// Disarm V8 weak callbacks on every surviving wrapper. ObjectWrap's
+		// WeakCallback is inlined into this addon's .node binary, so if any
+		// callback fires after the module loader unloads us (during V8's
+		// final GC inside Isolate::Deinit), it dispatches into unmapped
+		// memory and crashes the worker. See issue #1476.
+		for (node::ObjectWrap* w : addon->wrappers) {
+			w->persistent().ClearWeak();
+			w->persistent().Reset();
+		}
+		addon->wrappers.clear();
 		delete addon;
 	}
 
@@ -44,4 +54,9 @@ struct Addon {
 	sqlite3_uint64 next_id;
 	CS cs;
 	std::set<Database*, Database::CompareDatabase> dbs;
+	// Every live ObjectWrap-derived instance (Database, Statement, Backup,
+	// StatementIterator) registers here on construction and removes itself
+	// on destruction. Used by Cleanup to disarm V8 weak callbacks at addon
+	// teardown - see issue #1476.
+	std::set<node::ObjectWrap*> wrappers;
 };

--- a/src/objects/backup.cpp
+++ b/src/objects/backup.cpp
@@ -7,6 +7,7 @@ Backup::Backup(
 ) :
 	node::ObjectWrap(),
 	db(db),
+	addon(db->GetAddon()),
 	dest_handle(dest_handle),
 	backup_handle(backup_handle),
 	id(id),
@@ -16,10 +17,12 @@ Backup::Backup(
 	assert(dest_handle != NULL);
 	assert(backup_handle != NULL);
 	db->AddBackup(this);
+	addon->wrappers.insert(this);
 }
 
 Backup::~Backup() {
 	if (alive) db->RemoveBackup(this);
+	addon->wrappers.erase(this);
 	CloseHandles();
 }
 

--- a/src/objects/backup.hpp
+++ b/src/objects/backup.hpp
@@ -28,6 +28,7 @@ private:
 	static NODE_METHOD(JS_close);
 
 	Database* const db;
+	Addon* const addon;
 	sqlite3* const dest_handle;
 	sqlite3_backup* const backup_handle;
 	const sqlite3_uint64 id;

--- a/src/objects/database.cpp
+++ b/src/objects/database.cpp
@@ -31,10 +31,12 @@ Database::Database(
 	backups() {
 	assert(db_handle != NULL);
 	addon->dbs.insert(this);
+	addon->wrappers.insert(this);
 }
 
 Database::~Database() {
 	if (open) addon->dbs.erase(this);
+	addon->wrappers.erase(this);
 	CloseHandles();
 }
 

--- a/src/objects/statement-iterator.cpp
+++ b/src/objects/statement-iterator.cpp
@@ -1,6 +1,7 @@
 StatementIterator::StatementIterator(Statement* stmt, bool bound) :
 	node::ObjectWrap(),
 	stmt(stmt),
+	addon(stmt->db->GetAddon()),
 	handle(stmt->handle),
 	db_state(stmt->db->GetState()),
 	bound(bound),
@@ -16,12 +17,15 @@ StatementIterator::StatementIterator(Statement* stmt, bool bound) :
 	assert(db_state->iterators < USHRT_MAX);
 	stmt->locked = true;
 	db_state->iterators += 1;
+	addon->wrappers.insert(this);
 }
 
 // The ~Statement destructor currently covers any state this object creates.
 // Additionally, we actually DON'T want to revert stmt->locked or db_state
 // ->iterators in this destructor, to ensure deterministic database access.
-StatementIterator::~StatementIterator() {}
+StatementIterator::~StatementIterator() {
+	addon->wrappers.erase(this);
+}
 
 void StatementIterator::Next(NODE_ARGUMENTS info) {
 	assert(alive == true);

--- a/src/objects/statement-iterator.hpp
+++ b/src/objects/statement-iterator.hpp
@@ -40,6 +40,7 @@ private:
 	static NODE_METHOD(JS_symbolIterator);
 
 	Statement* const stmt;
+	Addon* const addon;
 	sqlite3_stmt* const handle;
 	Database::State* const db_state;
 	const bool bound;

--- a/src/objects/statement.cpp
+++ b/src/objects/statement.cpp
@@ -6,6 +6,7 @@ Statement::Statement(
 ) :
 	node::ObjectWrap(),
 	db(db),
+	addon(db->GetAddon()),
 	handle(handle),
 	extras(new Extras(id)),
 	alive(true),
@@ -20,10 +21,12 @@ Statement::Statement(
 	assert(db->GetState()->open);
 	assert(!db->GetState()->busy);
 	db->AddStatement(this);
+	addon->wrappers.insert(this);
 }
 
 Statement::~Statement() {
 	if (alive) db->RemoveStatement(this);
+	addon->wrappers.erase(this);
 	CloseHandles();
 	delete extras;
 }

--- a/src/objects/statement.hpp
+++ b/src/objects/statement.hpp
@@ -46,6 +46,7 @@ private:
 	static NODE_GETTER(JS_busy);
 
 	Database* const db;
+	Addon* const addon;
 	sqlite3_stmt* const handle;
 	Extras* const extras;
 	bool alive;


### PR DESCRIPTION
## Summary

- Fixes #1476: workers that opened a `Database` and exited abruptly (uncaught throw or `process.exit`) would SIGSEGV during isolate teardown when better-sqlite3 was loaded only in the worker thread.
- Root cause: every wrapper (`Database`, `Statement`, `Backup`, `StatementIterator`) inherits from `node::ObjectWrap`, whose V8 weak callback (`ObjectWrap::WeakCallback` from `node_object_wrap.h`) is inlined into the addon's own `.node` binary. When the worker isolate is the only loader, Node unloads the binary between `AddEnvironmentCleanupHook` firing and the final GC inside `Isolate::Deinit` → `CppHeap::StartDetachingIsolate`, leaving V8 to invoke a function pointer into now-unmapped memory. The macOS crash report confirms `better_sqlite3.node` is absent from the loaded-image list and the faulting address sits in the unmapped gap just below `libnode`.
- Fix:
  1. Track every live `ObjectWrap`-derived instance in a new `Addon::wrappers` set. Each wrapper class registers on construction and removes itself on destruction. `Statement`, `Backup`, and `StatementIterator` now also store an `Addon*` directly so their destructors can erase without dereferencing a possibly-freed parent.
  2. In `Addon::Cleanup`, close sqlite resources of any open databases (`Database::CloseHandles()` cascades into child `Statement` and `Backup` handles), then manually `ClearWeak()` + `Reset()` every wrapper still alive in `Addon::wrappers`. Because the set contains every constructed-but-not-destructed wrapper, this disarms every armed callback in the addon — reachable or not.

After `Cleanup` returns, no bsqlite weak callback is armed, so V8's later teardown GC has nothing to invoke into the about-to-be-unloaded binary.

## Test plan

- [x] Reproduce against the issue's exact repro on Node v26, macOS arm64, `better-sqlite3@12.10.0`, `typeorm@1.0.0`: 5/5 SIGSEGV before patch, 30/30 clean worker exits after across the variants below (5 iterations × 6 scenarios).
- [x] Variants verified clean after patch:
  - Unreachable `new Database(':memory:')` followed by sync throw.
  - Unreachable `new Database(':memory:')` followed by `process.exit(0)`.
  - Globally-rooted `Database` then throw.
  - Globally-rooted `Database` + `Statement` then throw.
  - Orphaned `Statement` (`db.close()` then throw, statement still rooted on `globalThis`).
  - Natural worker completion (no throw, no `exit`).
- [x] `npm test` → 311/311 passing on macOS arm64.