### PR TITLE
harden(deps): verify SHA3-256 of downloaded SQLite source archive

### DIFF
--- a/deps/download.sh
+++ b/deps/download.sh
@@ -21,6 +21,10 @@
 YEAR="2026"
 VERSION="3530100"
 
+# SHA3-256 of sqlite-src-$VERSION.zip as published at
+# https://www.sqlite.org/download.html. Update together with VERSION.
+EXPECTED_SHA3="27cfc9264b2188fd17f811a8c03424eb65391c2ef9874cbfc860ea25f4322363"
+
 # Defines below are sorted alphabetically
 DEFINES="
 HAVE_INT16_T=1
@@ -75,6 +79,15 @@ export CFLAGS=`echo $(echo "$DEFINES" | sed -e "/^\s*$/d" -e "s/^/-D/")`
 
 echo "downloading source..."
 curl -#f "https://www.sqlite.org/$YEAR/sqlite-src-$VERSION.zip" > "$TEMP/source.zip" || exit 1
+
+echo "verifying source integrity..."
+ACTUAL_SHA3=$(node -e "const c=require('crypto'),f=require('fs');const h=c.createHash('sha3-256');h.update(f.readFileSync(process.argv[1]));console.log(h.digest('hex'))" "$TEMP/source.zip") || exit 1
+if [ "$ACTUAL_SHA3" != "$EXPECTED_SHA3" ]; then
+  echo "ERROR: SHA3-256 mismatch for sqlite-src-$VERSION.zip" >&2
+  echo "  expected: $EXPECTED_SHA3" >&2
+  echo "  actual:   $ACTUAL_SHA3" >&2
+  exit 1
+fi
 
 echo "extracting source..."
 unzip "$TEMP/source.zip" -d "$TEMP" > /dev/null || exit 1


### PR DESCRIPTION
## Summary

Addresses #1478. `deps/download.sh` fetched the SQLite source zip from sqlite.org over HTTPS without verifying its integrity. This PR pins the published SHA3-256 of `sqlite-src-$VERSION.zip` alongside `YEAR` / `VERSION` and verifies it after `curl` and before `unzip`. On mismatch the script prints expected vs. actual digest and exits non-zero.

## Scope

This is **maintainer workflow integrity**, not end-user install security. End users never run `deps/download.sh` — they either use `prebuild-install` or compile the already-bundled `sqlite3.c` checked into the repo. The script runs only when a maintainer refreshes the bundled amalgamation for a new SQLite version, via `npm run download`. The fix is therefore defense-in-depth for that pipeline: it detects archive drift, CDN/cache corruption, and post-pin upstream tampering. It does **not** establish a full trusted release chain — SQLite publishes hashes from the same HTTPS origin as the zips, so an attacker controlling both could defeat it.

## Implementation notes

- The hash is computed with `node -e "...crypto.createHash('sha3-256')..."` rather than a shell tool. macOS bundled `shasum` does not support SHA3; using Node avoids portability/coreutils differences. Node is already required by this npm project (`engines.node` is 20+, and `sha3-256` has been available in `crypto` since Node 10).
- The expected hash is pinned inline next to `VERSION` so they stay visually paired — when bumping `VERSION`, the maintainer updates `EXPECTED_SHA3` from the matching row on https://www.sqlite.org/download.html.
- Verification runs after the download and before extraction. A bad archive never reaches `unzip`.

## Test plan

- [x] Pre-flight: locally `curl`'d `https://www.sqlite.org/2026/sqlite-src-3530100.zip` (14,515,734 bytes, 13.84 MiB), computed SHA3-256 with Node's `crypto`, and cross-checked the value against sqlite.org's download page. Both match: `27cfc9264b2188fd17f811a8c03424eb65391c2ef9874cbfc860ea25f4322363`.
- [x] Positive: genuine zip → ACTUAL matches EXPECTED, script continues. Verified.
- [x] Negative: appended one byte to a copy of the zip → ACTUAL ≠ EXPECTED → error message printed, exit 1. Verified.
- [x] On `node` missing: `node -e ...` exits non-zero, command substitution propagates, `|| exit 1` stops the script.