### PR TITLE
Fix Electron v42 build errors on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ env:
 
   # Electron v39 EOL = 2026-05-05. v40 EOL = 2026-06-30. v41 EOL = 2026-08-25. v42 EOL = 2026-09-22.
   # Electron 39+ requires GCC 11+ for <source_location> header (bookworm).
-  ELECTRON_BUILD_CMD_MODERN: npx --no-install prebuild -r electron -t 39.0.0 -t 40.0.0 -t 41.0.0 -t 42.0.0 --include-regex 'better_sqlite3.node$'
+  ELECTRON_BUILD_CMD_MODERN: npx --no-install prebuild -r electron -t 39.0.0 -t 40.0.0 -t 41.0.0 -t 42.3.0 --include-regex 'better_sqlite3.node$'
 
 jobs:
   test:


### PR DESCRIPTION
Use the Electron version with the https://github.com/electron/electron/pull/51695 patch for builds. Fixes the build error in the `v12.11.0` release.