### PR TITLE
Upgrade the Node.js version to v24 on GitHub actions jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,7 +105,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org
       - name: Upgrade npm for OIDC support
         run: npm install -g npm@latest
@@ -127,7 +127,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
       - if: ${{ startsWith(matrix.os, 'windows') }}
         run: pip.exe install setuptools
       - if: ${{ startsWith(matrix.os, 'macos') }}

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
       - name: Configure user
         run: |
           git config --local user.name "${{ github.actor }}"

--- a/.github/workflows/update-sqlite.yml
+++ b/.github/workflows/update-sqlite.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
       - name: Create new update branch
         run: git checkout -b sqlite-update-${{ env.ENV_VERSION }}
       - name: Update download script


### PR DESCRIPTION
Here we go again. Failed release after failed release. 🙄

There's simply no way to predict these things other than constantly studying dependency releases, it seems. I even tested everything except the publish job before the release, on a [staging repo](https://github.com/m4heshd/bs3-staging/actions/runs/29363132299). And boom, now the [publish job failed](https://github.com/WiseLibs/better-sqlite3/actions/runs/29393595581/job/87307088730) because of `npm install -g npm@latest` now defaulting to npm 12, which dropped support for EOLed Node v20.

@JoshuaWise needs to manually push `v12.12.0` to the registry, and this PR should "fix" things going forward.