### PR TITLE
validate the parameters of table properly

### DIFF
--- a/lib/methods/table.js
+++ b/lib/methods/table.js
@@ -55,7 +55,7 @@ function parseTableDefinition(def, verb, moduleName) {
 
 	// Validate "columns" property
 	let columns = def.columns;
-	if (!Array.isArray(columns) || !(columns = [...columns]).every(x => typeof x === 'string')) {
+	if (!Array.isArray(columns) || !isStringArray(columns = [...columns])) {
 		throw new TypeError(`Virtual table module "${moduleName}" ${verb} a table definition with an invalid "columns" property (should be an array of strings)`);
 	}
 	if (columns.length !== new Set(columns).size) {
@@ -69,7 +69,7 @@ function parseTableDefinition(def, verb, moduleName) {
 	let parameters;
 	if (hasOwnProperty.call(def, 'parameters')) {
 		parameters = def.parameters;
-		if (!Array.isArray(parameters) || !(parameters = [...parameters]).every(x => typeof x === 'string')) {
+		if (!Array.isArray(parameters) || !isStringArray(parameters = [...parameters])) {
 			throw new TypeError(`Virtual table module "${moduleName}" ${verb} a table definition with an invalid "parameters" property (should be an array of strings)`);
 		}
 	} else {
@@ -187,3 +187,9 @@ const { apply } = Function.prototype;
 const GeneratorFunctionPrototype = Object.getPrototypeOf(function*(){});
 const identifier = str => `"${str.replace(/"/g, '""')}"`;
 const defer = x => () => x;
+const isStringArray = (arr) => {
+	for (let i = 0; i < arr.length; ++i) {
+		if (typeof arr[i] !== 'string') return false;
+	}
+	return true;
+};

--- a/test/34.database.table.js
+++ b/test/34.database.table.js
@@ -54,6 +54,19 @@ describe('Database#table()', function () {
 		expect(() => this.db.table('g', { parameters: ['x'], columns: ['x'], rows: function*(){} })).to.throw(TypeError);
 		expect(() => this.db.table('h', { parameters: [...Array(33)].map((_, i) => `p${i}`), columns: ['foo'], rows: function*(){} })).to.throw(RangeError);
 	});
+	it('should reject non-string parameters even if Array.prototype.every is polluted', function () {
+		const original = Array.prototype.every;
+		Array.prototype.every = () => true;
+		let thrown;
+		try {
+			this.db.table('a', { parameters: [new String('x')], columns: ['foo'], rows: function*(){} });
+		} catch (err) {
+			thrown = err;
+		} finally {
+			Array.prototype.every = original;
+		}
+		expect(thrown).to.be.an.instanceof(TypeError);
+	});
 	it('should throw an exception if the "rows" option is invalid', function () {
 		expect(() => this.db.table('a', { columns: ['x'] })).to.throw(TypeError);
 		expect(() => this.db.table('b', { columns: ['x'], rows: undefined })).to.throw(TypeError);


### PR DESCRIPTION
This PR fixes the issue in https://github.com/WiseLibs/better-sqlite3/issues/1502#issuecomment-5066980373, which causes an uncatchable SIGABRT through the public JS API of better-sqlite3.

The fix is at the JS layer where it ensures that the parameter list of a table is indeed a string array.

**Important note**: the more robust fix is to perform this check at the C++ layer though.