### PR TITLE
use Ubuntu 22.04-arm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
         include:
           - os: ubuntu-22.04
             target: linux-x64
-          - os: ubuntu-24.04-arm
+          - os: ubuntu-22.04-arm
             target: linux-arm64
           - os: macos-15-intel
             target: darwin-x64


### PR DESCRIPTION
Downgrade the used Ubuntu ARM version to 22.04 as it is used for the x64 Linux build.

This should lower the required GLIBC version for the ARM build and allow loading better-sqlite3 on Debian 12 (#1509) 